### PR TITLE
Introduce base print class

### DIFF
--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_fitest_jpeg_photoimages_1photodpoftestforbat_hp945_vader_dcim_100hp945_hpim0069le_example_jpg_100kb.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_fitest_jpeg_photoimages_1photodpoftestforbat_hp945_vader_dcim_100hp945_hpim0069le_example_jpg_100kb.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,43 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray."""
-        media_input = self.media.get_media_configuration().get('inputs', [])
-
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:simple print job of jpeg file of photoimages 1photodpoftestforbat hp945 vader dcim 100hp945 hpim0069

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_largefile.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_largefile.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_1photodpoftestforbat_hp945_vader_dcim_100hp945_hpim0071.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_1photodpoftestforbat_hp945_vader_dcim_100hp945_hpim0071.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_1.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_1.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_101.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_101.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_102.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_102.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_104.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_104.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_108.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_108.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_21.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_21.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_22.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_22.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_24.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_24.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_26.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_26.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_45.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_45.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_50.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_300_2000_quality_test_photos_50.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_5m_img_1178.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_5m_img_1178.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -46,54 +26,6 @@ class TestWhenPrintingJPEGFile:
 
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
-
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-
 
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_differentfilesize_3m_dsc00696.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_differentfilesize_3m_dsc00696.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -46,53 +26,6 @@ class TestWhenPrintingJPEGFile:
 
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
-
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
 
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_differentfilesize_4m_211canon_img_0002.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_differentfilesize_4m_211canon_img_0002.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,53 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:simple print job of jpeg file of photoimages differentfilesize 4m 211canon img 0002

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_frequently_usedjpeg_pb250677.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_frequently_usedjpeg_pb250677.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,53 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:simple print job of jpeg file of photoimages frequently-usedjpeg pb250677

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_frequently_usedjpeg_pb260776.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_frequently_usedjpeg_pb260776.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -46,53 +26,6 @@ class TestWhenPrintingJPEGFile:
 
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
-
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
 
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_redeyeimages_250nonredeye_img_6487.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_redeyeimages_250nonredeye_img_6487.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_smalljpg_imge26_medium.py
+++ b/jpeg_nuevo/basic-functionality/test_when_printing_jpeg_photoimages_smalljpg_imge26_medium.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/custom-sizes/test_when_printing_jpeg_custom_sizes.py
+++ b/jpeg_nuevo/custom-sizes/test_when_printing_jpeg_custom_sizes.py
@@ -1,10 +1,6 @@
 from dunetuf.print.output.intents import Intents, MediaSize
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip, get_emulation_ip
 from dunetuf.cdm import get_cdm_instance
@@ -14,15 +10,12 @@ from dunetuf.emulation.print import PrintEmulation
 from dunetuf.print.print_common_types import MediaInputIds,  MediaType, MediaOrientation
 from dunetuf.configuration import Configuration
 from dunetuf.print.output_verifier import OutputVerifier
+from jpeg_nuevo.print_base import TestWhenPrinting
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -41,19 +34,6 @@ class TestWhenPrintingJPEGFile:
     def teardown_class(cls):
         """Release shared test resources."""
 
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
-
     def teardown_method(self):
         """Clean up resources after each test."""
         # Clear job queue
@@ -67,52 +47,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
     
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Jpeg test using CS(300X200)-150-L.jpg

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_autoalign_0921fromhp_autoalign_landscape_3x2_dsc_0967.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_autoalign_0921fromhp_autoalign_landscape_3x2_dsc_0967.py
@@ -1,9 +1,5 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip, get_emulation_ip
 from dunetuf.cdm import get_cdm_instance
@@ -12,15 +8,12 @@ from dunetuf.udw import TclSocketClient
 from dunetuf.emulation.print import PrintEmulation
 from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType, MediaOrientation
 from dunetuf.configuration import Configuration
+from jpeg_nuevo.print_base import TestWhenPrinting
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -38,19 +31,6 @@ class TestWhenPrintingJPEGFile:
     def teardown_class(cls):
         """Release shared test resources."""
 
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
-
     def teardown_method(self):
         """Clean up resources after each test."""
         # Clear job queue
@@ -64,52 +44,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
     
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of autoalign 0921fromhp autoalign landscape 3x2 dsc 0967

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_autoalign_0921fromhp_autoalign_portrait_5x4_dscn1385.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_autoalign_0921fromhp_autoalign_portrait_5x4_dscn1385.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,53 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
     
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of autoalign 0921fromhp autoalign portrait 5x4 dscn1385

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_cr222024_photo.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_cr222024_photo.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,53 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of cr222024_photo

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_jpg5.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_jpg5.py
@@ -1,27 +1,20 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip, get_emulation_ip
 from dunetuf.cdm import get_cdm_instance
 from dunetuf.udw.udw import get_underware_instance
 from dunetuf.udw import TclSocketClient
 from dunetuf.emulation.print import PrintEmulation
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 from dunetuf.print.print_common_types import MediaSize, MediaType
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -38,19 +31,6 @@ class TestWhenPrintingJPEGFile:
     def teardown_class(cls):
         """Release shared test resources."""
 
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
-
     def teardown_method(self):
         """Clean up resources after each test."""
         # Clear job queue
@@ -64,53 +44,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of jpg5

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_10_corrupt_dpof_a1.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_10_corrupt_dpof_a1.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,52 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
     
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of photoimages 10 corrupt dpof a1

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_10_corrupt_dpof_a2.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_10_corrupt_dpof_a2.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,52 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of photoimages 10 corrupt dpof a2

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_autoalign_landscape_5x4_dscn1190.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_autoalign_landscape_5x4_dscn1190.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,53 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of photoimages autoalign landscape 5x4 dscn1190

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_autoalign_portrait_3x4_img_0322.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_autoalign_portrait_3x4_img_0322.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_corrupted_image_hpim0086.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_corrupted_image_hpim0086.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_defectiveimages_cr222024_photo.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_defectiveimages_cr222024_photo.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,52 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of photoimages defectiveimages cr222024 photo

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_exif2_3_exif2_3_dsci0013.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_exif2_3_exif2_3_dsci0013.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,53 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of photoimages_exif2.3_exif2.3_dsci0013

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_jpeg_greater3mb_dsc00452.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_jpeg_greater3mb_dsc00452.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,53 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of photoimages_jpeg_greater3mb_dsc00452

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_jpeg_greater3mb_dsc00462.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_jpeg_greater3mb_dsc00462.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,53 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of photoimages_jpeg_greater3mb_dsc00462

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_lessthan3megapixelphoto_dscn4744.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_lessthan3megapixelphoto_dscn4744.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,52 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of photoimages_lessthan3megapixelphoto_dscn4744

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_panoramaimages_hpr837_1m_2m_sr016231.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_panoramaimages_hpr837_1m_2m_sr016231.py
@@ -1,40 +1,20 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.media.media_handling import MediaHandling
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.media_handling = MediaHandling()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -49,53 +29,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of photoimages_panoramaimages_hpr837_1m-2m_sr016231

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_panoramaimages_hpr927_5m_3.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_panoramaimages_hpr927_5m_3.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_resolution_jpg_jpg1760x1168.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_resolution_jpg_jpg1760x1168.py
@@ -1,39 +1,19 @@
 import pytest
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -48,53 +28,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of photoimages resolution jpg jpg1760x1168

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_resolution_jpg_jpg5.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_resolution_jpg_jpg5.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,52 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
     
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of photoimages resolution jpg jpg5

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_totalblack_blank_image.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_photoimages_totalblack_blank_image.py
@@ -1,27 +1,20 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip, get_emulation_ip
 from dunetuf.cdm import get_cdm_instance
 from dunetuf.udw.udw import get_underware_instance
 from dunetuf.udw import TclSocketClient
 from dunetuf.emulation.print import PrintEmulation
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 from dunetuf.print.print_common_types import MediaSize, MediaType
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -38,19 +31,6 @@ class TestWhenPrintingJPEGFile:
     def teardown_class(cls):
         """Release shared test resources."""
 
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
-
     def teardown_method(self):
         """Clean up resources after each test."""
         # Clear job queue
@@ -64,52 +44,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
     
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of photoimages_totalblack_blank_image

--- a/jpeg_nuevo/high-value/test_when_printing_jpeg_test_jpeg_photoimages_exif2_3_exif2_3_dsci0018.py
+++ b/jpeg_nuevo/high-value/test_when_printing_jpeg_test_jpeg_photoimages_exif2_3_exif2_3_dsci0018.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,52 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
     
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: simple print job of jpeg file of photoimages_exif2.3_exif2.3_dsci0018

--- a/jpeg_nuevo/large_media_sizes/test_when_printing_jpeg_large_media_size_a0.py
+++ b/jpeg_nuevo/large_media_sizes/test_when_printing_jpeg_large_media_size_a0.py
@@ -1,41 +1,21 @@
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.print.output_verifier import OutputVerifier
 from dunetuf.print.output.intents import Intents, MediaSize, MediaSource, MediaSizeID, get_media_source
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 A0_WIDTH_IN_INCH = 841000 / 25400.0
 A0_HEIGHT_IN_INCH = 1189000 / 25400.0
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.outputverifier = OutputVerifier(cls.outputsaver)
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/large_media_sizes/test_when_printing_jpeg_large_media_size_a1.py
+++ b/jpeg_nuevo/large_media_sizes/test_when_printing_jpeg_large_media_size_a1.py
@@ -1,41 +1,21 @@
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.print.output_verifier import OutputVerifier
 from dunetuf.print.output.intents import Intents, MediaSize, MediaSource, MediaSizeID, get_media_source
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 A1_WIDTH_IN_INCH = 594000 / 25400
 A1_HEIGHT_IN_INCH = 841000 / 25400
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.outputverifier = OutputVerifier(cls.outputsaver)
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/large_media_sizes/test_when_printing_jpeg_large_media_size_a2.py
+++ b/jpeg_nuevo/large_media_sizes/test_when_printing_jpeg_large_media_size_a2.py
@@ -1,42 +1,22 @@
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.print.output.intents import Intents, MediaSize, MediaSource, MediaSizeID, get_media_source
 from dunetuf.print.output_verifier import OutputVerifier
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 A2_WIDTH_IN_INCH = 420000 / 25400
 A2_HEIGHT_IN_INCH = 594000 / 25400
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.outputverifier = OutputVerifier(cls.outputsaver)
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/large_media_sizes/test_when_printing_jpeg_large_media_size_a3.py
+++ b/jpeg_nuevo/large_media_sizes/test_when_printing_jpeg_large_media_size_a3.py
@@ -1,40 +1,20 @@
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.print.output.intents import Intents, MediaSize, MediaSource, get_media_source
 from dunetuf.print.output_verifier import OutputVerifier
 import logging
+from jpeg_nuevo.print_base import TestWhenPrinting
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.outputverifier = OutputVerifier(cls.outputsaver)
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -49,53 +29,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Jpeg test using A3-150-L.jpg

--- a/jpeg_nuevo/print_base.py
+++ b/jpeg_nuevo/print_base.py
@@ -1,0 +1,75 @@
+import logging
+from dunetuf.job.job_queue.job_queue import JobQueue
+from dunetuf.job.job_history.job_history import JobHistory
+from dunetuf.print.print_new import Print
+from dunetuf.media.media import Media
+
+
+class TestWhenPrinting:
+    """Base class providing common print test setup and helpers."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.job_queue = JobQueue()
+        cls.job_history = JobHistory()
+        cls.print = Print()
+        cls.media = Media()
+
+        # Ensure clean state before tests
+        cls.job_queue.cancel_all_jobs()
+        cls.job_queue.wait_for_queue_empty()
+        cls.job_history.clear()
+        cls.job_history.wait_for_history_empty()
+        cls.default_configuration = cls.media.get_media_configuration()
+
+    def _update_media_input_config(self, default_tray, media_size, media_type):
+        """Update media configuration for a specific tray."""
+        media_input = self.media.get_media_configuration().get("inputs", [])
+
+        for input_config in media_input:
+            if input_config.get("mediaSourceId") == default_tray:
+                if media_size == "custom":
+                    supported_inputs = self.media.get_media_capabilities().get(
+                        "supportedInputs", []
+                    )
+                    capability = next(
+                        (
+                            cap
+                            for cap in supported_inputs
+                            if cap.get("mediaSourceId") == default_tray
+                        ),
+                        {},
+                    )
+                    input_config["currentMediaWidth"] = capability.get(
+                        "mediaWidthMaximum"
+                    )
+                    input_config["currentMediaLength"] = capability.get(
+                        "mediaLengthMaximum"
+                    )
+                    input_config["currentResolution"] = capability.get("resolution")
+
+                input_config["mediaSize"] = media_size
+                input_config["mediaType"] = media_type
+
+                self.media.update_media_configuration({"inputs": [input_config]})
+                return
+
+        logging.warning(f"No media input found for tray: {default_tray}")
+
+    def _get_tray_and_media_sizes(self, tray=None):
+        """Get the default tray and its supported media sizes."""
+        if tray is None:
+            tray = self.media.get_default_source()
+        supported_inputs = self.media.get_media_capabilities().get(
+            "supportedInputs", []
+        )
+        media_sizes = next(
+            (
+                i.get("supportedMediaSizes", [])
+                for i in supported_inputs
+                if i.get("mediaSourceId") == tray
+            ),
+            [],
+        )
+        logging.info("Supported Media Sizes (%s): %s", tray, media_sizes)
+        return tray, media_sizes

--- a/jpeg_nuevo/test_when_printing_jpeg_2686.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_2686.py
@@ -1,26 +1,19 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip, get_emulation_ip
 from dunetuf.cdm import get_cdm_instance
 from dunetuf.udw.udw import get_underware_instance
 from dunetuf.udw import TclSocketClient
 from dunetuf.emulation.print import PrintEmulation
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType, MediaOrientation
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -37,19 +30,6 @@ class TestWhenPrintingJPEGFile:
     def teardown_class(cls):
         """Release shared test resources."""
 
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
-
     def teardown_method(self):
         """Clean up resources after each test."""
         # Clear job queue
@@ -63,19 +43,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Jpeg test using **2686.jpg

--- a/jpeg_nuevo/test_when_printing_jpeg_9587eb968f64f6d6fc20e5b3d0d71abc.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_9587eb968f64f6d6fc20e5b3d0d71abc.py
@@ -1,37 +1,17 @@
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_corrupted_file.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_corrupted_file.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_file_example_JPG_100kB.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_file_example_JPG_100kB.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,53 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg file of 100kB from *file_example_JPG_100kB.jpg

--- a/jpeg_nuevo/test_when_printing_jpeg_file_example_JPG_1MB.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_file_example_JPG_1MB.py
@@ -1,9 +1,5 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip, get_emulation_ip
 from dunetuf.cdm import get_cdm_instance
@@ -12,16 +8,13 @@ from dunetuf.udw import TclSocketClient
 from dunetuf.emulation.print import PrintEmulation
 from dunetuf.print.print_common_types import MediaType, MediaOrientation
 from dunetuf.configuration import Configuration
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -39,19 +32,6 @@ class TestWhenPrintingJPEGFile:
     def teardown_class(cls):
         """Release shared test resources."""
 
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
-
     def teardown_method(self):
         """Clean up resources after each test."""
         # Clear job queue
@@ -65,52 +45,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
     
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose: Simple Print job of Jpeg file of 1MB from **

--- a/jpeg_nuevo/test_when_printing_jpeg_file_example_JPG_2500kB.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_file_example_JPG_2500kB.py
@@ -1,40 +1,20 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.media.media_handling import MediaHandling
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.media_handling = MediaHandling()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -49,52 +29,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg file of 2500kB from *file_example_JPG_2500kB.jpg

--- a/jpeg_nuevo/test_when_printing_jpeg_file_example_JPG_500kB.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_file_example_JPG_500kB.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_low_resolution.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_low_resolution.py
@@ -1,9 +1,5 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip, get_emulation_ip
 from dunetuf.configuration import Configuration
@@ -12,16 +8,13 @@ from dunetuf.udw.udw import get_underware_instance
 from dunetuf.udw import TclSocketClient
 from dunetuf.emulation.print import PrintEmulation
 from dunetuf.print.print_common_types import MediaInputIds,MediaSize, MediaType, MediaOrientation, TrayLevel
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -40,19 +33,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_no_resolution_in_file.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_no_resolution_in_file.py
@@ -1,41 +1,21 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_verifier import OutputVerifier
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.outputverifier = OutputVerifier(cls.outputsaver)
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -50,53 +30,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Test jpeg job when no resolution in specified in file
@@ -147,4 +80,3 @@ class TestWhenPrintingJPEGFile:
         self.outputverifier.verify_page_width(Intents.printintent, 3000)
         self.outputverifier.verify_page_height(Intents.printintent, 3749)
         self.outputsaver.operation_mode('NONE')
-

--- a/jpeg_nuevo/test_when_printing_jpeg_out_of_range_behavior.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_out_of_range_behavior.py
@@ -1,22 +1,15 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.print.output_verifier import OutputVerifier
 from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
 from dunetuf.media.media_handling import MediaHandling
+from jpeg_nuevo.print_base import TestWhenPrinting
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.outputverifier = OutputVerifier(cls.outputsaver)
         cls.media_handling = MediaHandling()
@@ -24,19 +17,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -51,52 +31,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Test jpeg out of range behavior on roll
@@ -164,4 +98,3 @@ class TestWhenPrintingJPEGFile:
         logging.info("Validate current crc with master crc")
         assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
         self.outputsaver.operation_mode('NONE')
-

--- a/jpeg_nuevo/test_when_printing_jpeg_pdlmh_printableheight_zero.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_pdlmh_printableheight_zero.py
@@ -1,22 +1,15 @@
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.cdm import get_cdm_instance
 from dunetuf.metadata import get_ip
+from jpeg_nuevo.print_base import TestWhenPrinting
  
  
  
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -24,19 +17,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_pdlmh_printablewidth_zero.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_pdlmh_printablewidth_zero.py
@@ -1,21 +1,14 @@
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.cdm import get_cdm_instance
 from dunetuf.metadata import get_ip
+from jpeg_nuevo.print_base import TestWhenPrinting
 
  
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -23,19 +16,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_performance_10_2000cm.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_performance_10_2000cm.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_performance_faces.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_performance_faces.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_performance_village.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_performance_village.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_print_multiple_jobs.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_print_multiple_jobs.py
@@ -1,22 +1,15 @@
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.localization.LocalizationHelper import LocalizationHelper
 from dunetuf.ui.spice import Spice
 from dunetuf.metadata import get_qmltest_port, get_screen_capture, get_ip
 from dunetuf.network.net import Network
+from jpeg_nuevo.print_base import TestWhenPrinting
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         port = get_qmltest_port()
         screen_capture = get_screen_capture()
@@ -27,24 +20,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        # Go to homescreen        
-        self.spice.cleanSystemEventAndWaitHomeScreen()
-        self.spice.wait_ready()
-        self.spice.goto_homescreen()
-
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_printfromusb_custom.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_printfromusb_custom.py
@@ -1,10 +1,7 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 @pytest.fixture(autouse=True)
 def setup_teardown_pdl_test(job, usbdevice):
@@ -29,32 +26,15 @@ def setup_teardown_pdl_test(job, usbdevice):
     job.wait_for_no_active_jobs()
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_regression_3Dgirls_JFIF_nounits_without_EXIF.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_regression_3Dgirls_JFIF_nounits_without_EXIF.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_regression_AdobeRGB_A4_100dpi.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_regression_AdobeRGB_A4_100dpi.py
@@ -1,23 +1,16 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip
 from dunetuf.cdm import get_cdm_instance
 from dunetuf.configuration import Configuration
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -26,19 +19,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -53,53 +33,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg Regression of AdobeRGB A4 100dpi Page from *AdobeRGB_A4_100dpi.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_regression_BGR_A4_100dpi.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_regression_BGR_A4_100dpi.py
@@ -1,10 +1,6 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
 from dunetuf.print.mapper import PrintMapper
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip, get_emulation_ip
 from dunetuf.cdm import get_cdm_instance
@@ -12,16 +8,13 @@ from dunetuf.udw.udw import get_underware_instance
 from dunetuf.udw import TclSocketClient
 from dunetuf.emulation.print import PrintEmulation
 from dunetuf.print.print_common_types import MediaSize, MediaType
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -39,19 +32,6 @@ class TestWhenPrintingJPEGFile:
     def teardown_class(cls):
         """Release shared test resources."""
 
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
-
     def teardown_method(self):
         """Clean up resources after each test."""
         # Clear job queue
@@ -65,43 +45,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray."""
-        media_input = self.media.get_media_configuration().get('inputs', [])
-
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg Regression of BGR A4 100dpi Page from *BGR_A4_100dpi.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_regression_SWOP_A4_100dpi.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_regression_SWOP_A4_100dpi.py
@@ -1,23 +1,16 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.configuration import Configuration
 from dunetuf.metadata import get_ip
 from dunetuf.cdm import get_cdm_instance
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -26,19 +19,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -53,44 +33,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray."""
-        media_input = self.media.get_media_configuration().get('inputs', [])
-
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg Regression of SWOP A4 100dpi Page from *SWOP_A4_100dpi.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_regression_faces_small.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_regression_faces_small.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,43 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray."""
-        media_input = self.media.get_media_configuration().get('inputs', [])
-
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg Regression of faces small Page from *faces_small.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_regression_sRGB_A4_100dpi.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_regression_sRGB_A4_100dpi.py
@@ -1,23 +1,16 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.configuration import Configuration
 from dunetuf.metadata import get_ip
 from dunetuf.cdm import get_cdm_instance
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -26,19 +19,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -53,44 +33,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray."""
-        media_input = self.media.get_media_configuration().get('inputs', [])
-
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg Regression of sRGB A4 100dpi Page from *sRGB_A4_100dpi.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_regression_untagged_argb_100dpi.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_regression_untagged_argb_100dpi.py
@@ -1,10 +1,6 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
 from dunetuf.print.mapper import PrintMapper
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip, get_emulation_ip
 from dunetuf.cdm import get_cdm_instance
@@ -13,16 +9,13 @@ from dunetuf.udw import TclSocketClient
 from dunetuf.emulation.print import PrintEmulation
 from dunetuf.print.print_common_types import MediaSize, MediaType
 from dunetuf.configuration import Configuration
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -41,19 +34,6 @@ class TestWhenPrintingJPEGFile:
     def teardown_class(cls):
         """Release shared test resources."""
 
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
-
     def teardown_method(self):
         """Clean up resources after each test."""
         # Clear job queue
@@ -67,43 +47,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray."""
-        media_input = self.media.get_media_configuration().get('inputs', [])
-
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:C52178011 Simple print job of Jpeg Regression of untagged argb 100dpi Page from *untagged_argb_100dpi.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_regression_untagged_cmyk_swop_100dpi.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_regression_untagged_cmyk_swop_100dpi.py
@@ -1,24 +1,17 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.configuration import Configuration
 from dunetuf.metadata import get_ip
 from dunetuf.cdm import get_cdm_instance
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -27,19 +20,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -55,43 +35,6 @@ class TestWhenPrintingJPEGFile:
         self.media.update_media_configuration(self.default_configuration)
 
     
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray."""
-        media_input = self.media.get_media_configuration().get('inputs', [])
-
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg Regression of untagged cmyk swop 100dpi Page from *untagged_cmyk_swop_100dpi.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_sRGB_A4_600dpi.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_sRGB_A4_600dpi.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,43 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
     
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray."""
-        media_input = self.media.get_media_configuration().get('inputs', [])
-
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of jpeg_sRGB_A4_600dpi

--- a/jpeg_nuevo/test_when_printing_jpeg_sRGB_A4_600dpi_checksum.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_sRGB_A4_600dpi_checksum.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.utility.systemtestpath import get_system_test_binaries_path
+from jpeg_nuevo.print_base import TestWhenPrinting
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_smalljob_on_largepaper.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_smalljob_on_largepaper.py
@@ -1,22 +1,15 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
 from dunetuf.media.media_handling import MediaHandling
 from dunetuf.print.output_verifier import OutputVerifier
+from jpeg_nuevo.print_base import TestWhenPrinting
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.outputverifier = OutputVerifier(cls.outputsaver)
         cls.media_handling = MediaHandling()
@@ -24,19 +17,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -50,54 +30,6 @@ class TestWhenPrintingJPEGFile:
 
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
-
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-
 
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
@@ -163,4 +95,3 @@ class TestWhenPrintingJPEGFile:
         logging.info("Validate current crc with master crc")
         assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
         self.outputsaver.operation_mode('NONE')
-

--- a/jpeg_nuevo/test_when_printing_jpeg_testimg.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testimg.py
@@ -1,22 +1,15 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip
 from dunetuf.cdm import get_cdm_instance
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -24,19 +17,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_testimgp.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testimgp.py
@@ -1,22 +1,15 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.cdm import get_cdm_instance
 from dunetuf.metadata import get_ip
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -24,19 +17,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_testorig.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testorig.py
@@ -1,22 +1,15 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.cdm import get_cdm_instance
 from dunetuf.metadata import get_ip
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -24,19 +17,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_testprog.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testprog.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -104,4 +84,3 @@ class TestWhenPrintingJPEGFile:
         assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
 
         logging.info("JPEG testprog Page- Print job completed successfully")
-

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_100x100rgb.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_100x100rgb.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,43 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray."""
-        media_input = self.media.get_media_configuration().get('inputs', [])
-
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg TestSuite 100x100 rgb Page from *100x100rgb.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_3Dgirls_JFIF_nounits_without_EXIF.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_3Dgirls_JFIF_nounits_without_EXIF.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_DemoImages.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_DemoImages.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_J.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_J.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,53 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg TestSuite J Page from *J.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_alt400mm_36inch_landscape.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_alt400mm_36inch_landscape.py
@@ -1,9 +1,5 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip, get_emulation_ip
 from dunetuf.cdm import get_cdm_instance
@@ -11,15 +7,12 @@ from dunetuf.udw.udw import get_underware_instance
 from dunetuf.udw import TclSocketClient
 from dunetuf.emulation.print import PrintEmulation
 from dunetuf.print.print_common_types import MediaInputIds,MediaSize, MediaType, MediaOrientation, TrayLevel
+from jpeg_nuevo.print_base import TestWhenPrinting
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -35,19 +28,6 @@ class TestWhenPrintingJPEGFile:
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_broken2.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_broken2.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -46,54 +26,6 @@ class TestWhenPrintingJPEGFile:
 
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
-
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
 
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_combo_SWOP_embedded.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_combo_SWOP_embedded.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_combo_aRGB_embedded.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_combo_aRGB_embedded.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_faces.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_faces.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_faces_small.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_faces_small.py
@@ -1,9 +1,5 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip, get_emulation_ip
 from dunetuf.cdm import get_cdm_instance
@@ -12,15 +8,12 @@ from dunetuf.udw import TclSocketClient
 from dunetuf.emulation.print import PrintEmulation
 from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType, MediaOrientation
 from dunetuf.configuration import Configuration
+from jpeg_nuevo.print_base import TestWhenPrinting
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -38,19 +31,6 @@ class TestWhenPrintingJPEGFile:
     def teardown_class(cls):
         """Release shared test resources."""
 
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
-
     def teardown_method(self):
         """Clean up resources after each test."""
         # Clear job queue
@@ -64,52 +44,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg TestSuite faces small Page from *faces_small.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_100_dpi.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_100_dpi.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,52 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg TestSuite lenna 100 dpi Page from *lenna_100_dpi.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_100_dpi_CMYK.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_100_dpi_CMYK.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,53 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
     
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg TestSuite lenna 100 dpi CMYK Page from *lenna_100_dpi_CMYK.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_100_dpi_EXIF_NONE.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_100_dpi_EXIF_NONE.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_100_dpi_gray.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_100_dpi_gray.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,53 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg TestSuite lenna 100 dpi gray Page from *lenna_100_dpi_gray.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_20dpcm.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_20dpcm.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_20dpcm_EXIF_NONE.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_20dpcm_EXIF_NONE.py
@@ -1,39 +1,19 @@
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -48,43 +28,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray."""
-        media_input = self.media.get_media_configuration().get('inputs', [])
-
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg TestSuite lenna 20dpcm EXIF NONE Page from *lenna_20dpcm_EXIF_NONE.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_without_resolution_info.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_without_resolution_info.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""
@@ -47,53 +27,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray.
-        
-        Args:
-            default_tray: Default tray identifier
-            media_size: Media size to set
-            media_type: Media type to set
-        """
-        media_input = self.media.get_media_configuration().get('inputs', [])
-        
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                # Handle custom media size configuration
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-                
-                # Update media properties
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-                
-                # Update configuration and return early
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-        
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
-    
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg TestSuite lenna without resolution info Page from *lenna_without_resolution_info.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_without_resolution_info_EXIF_NONE.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_lenna_without_resolution_info_EXIF_NONE.py
@@ -1,10 +1,6 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
 from dunetuf.print.mapper import PrintMapper
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip, get_emulation_ip
 from dunetuf.cdm import get_cdm_instance
@@ -12,16 +8,13 @@ from dunetuf.udw.udw import get_underware_instance
 from dunetuf.udw import TclSocketClient
 from dunetuf.emulation.print import PrintEmulation
 from dunetuf.print.print_common_types import MediaSize, MediaType
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -39,19 +32,6 @@ class TestWhenPrintingJPEGFile:
     def teardown_class(cls):
         """Release shared test resources."""
 
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
-
     def teardown_method(self):
         """Clean up resources after each test."""
         # Clear job queue
@@ -65,43 +45,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray."""
-        media_input = self.media.get_media_configuration().get('inputs', [])
-
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:Simple print job of Jpeg TestSuite lenna without resolution info EXIFNONE Page from *lenna_without_resolution_info_EXIF_NONE.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_parrots_Progressive_Interlaced.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_parrots_Progressive_Interlaced.py
@@ -1,10 +1,6 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
 from dunetuf.print.mapper import PrintMapper
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
 from dunetuf.metadata import get_ip, get_emulation_ip
 from dunetuf.cdm import get_cdm_instance
@@ -12,16 +8,13 @@ from dunetuf.udw.udw import get_underware_instance
 from dunetuf.udw import TclSocketClient
 from dunetuf.emulation.print import PrintEmulation
 from dunetuf.print.print_common_types import MediaSize, MediaType
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
         cls.ip_address = get_ip()
         cls.cdm = get_cdm_instance(cls.ip_address)
@@ -39,19 +32,6 @@ class TestWhenPrintingJPEGFile:
     def teardown_class(cls):
         """Release shared test resources."""
 
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
-
     def teardown_method(self):
         """Clean up resources after each test."""
         # Clear job queue
@@ -65,43 +45,6 @@ class TestWhenPrintingJPEGFile:
         # Reset media configuration to default
         self.media.update_media_configuration(self.default_configuration)
 
-    def _update_media_input_config(self, default_tray, media_size, media_type):
-        """Update media configuration for a specific tray."""
-        media_input = self.media.get_media_configuration().get('inputs', [])
-
-        for input_config in media_input:
-            if input_config.get('mediaSourceId') == default_tray:
-                if media_size == 'custom':
-                    supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-                    capability = next(
-                        (cap for cap in supported_inputs if cap.get('mediaSourceId') == default_tray),
-                        {}
-                    )
-                    input_config['currentMediaWidth'] = capability.get('mediaWidthMaximum')
-                    input_config['currentMediaLength'] = capability.get('mediaLengthMaximum')
-                    input_config['currentResolution'] = capability.get('resolution')
-
-                input_config['mediaSize'] = media_size
-                input_config['mediaType'] = media_type
-
-                self.media.update_media_configuration({'inputs': [input_config]})
-                return
-
-        logging.warning(f"No media input found for tray: {default_tray}")
-
-    def _get_tray_and_media_sizes(self, tray = None):
-        """Get the default tray and its supported media sizes.
-        
-        Returns:
-            tuple: (default_tray, media_sizes) where default_tray is the default source
-                   and media_sizes is a list of supported media sizes for that tray
-        """
-        if tray is None:
-            tray = self.media.get_default_source()
-        supported_inputs = self.media.get_media_capabilities().get('supportedInputs', [])
-        media_sizes = next((input.get('supportedMediaSizes', []) for input in supported_inputs if input.get('mediaSourceId') == tray), [])
-        logging.info('Supported Media Sizes (%s): %s', tray, media_sizes)
-        return tray, media_sizes
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
     +purpose:C52178010 Simple print job of Jpeg TestSuite parrots Progressive Interlaced Page from *parrots_Progressive_Interlaced.jpg file

--- a/jpeg_nuevo/test_when_printing_jpeg_testsuite_taggedRGB.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_testsuite_taggedRGB.py
@@ -1,38 +1,18 @@
 import logging
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""

--- a/jpeg_nuevo/test_when_printing_jpeg_webpage_upd_print.py
+++ b/jpeg_nuevo/test_when_printing_jpeg_webpage_upd_print.py
@@ -1,37 +1,17 @@
-from dunetuf.job.job_history.job_history import JobHistory
-from dunetuf.job.job_queue.job_queue import JobQueue
-from dunetuf.print.print_new import Print
 from dunetuf.print.print_common_types import MediaSize, MediaType
-from dunetuf.media.media import Media
 from dunetuf.print.output_saver import OutputSaver
+from jpeg_nuevo.print_base import TestWhenPrinting
 
 
-class TestWhenPrintingJPEGFile:
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
         """Initialize shared test resources."""
-        cls.job_queue = JobQueue()
-        cls.job_history = JobHistory()
-        cls.print = Print()
-        cls.media = Media()
         cls.outputsaver = OutputSaver()
 
     @classmethod
     def teardown_class(cls):
         """Release shared test resources."""
-
-    def setup_method(self):
-        """Clean up resources after each test."""
-        # Clear job queue
-        self.job_queue.cancel_all_jobs()
-        self.job_queue.wait_for_queue_empty()
-
-        # Clear job history
-        self.job_history.clear()
-        self.job_history.wait_for_history_empty()
-
-        # Get media configuration
-        self.default_configuration = self.media.get_media_configuration()
 
     def teardown_method(self):
         """Clean up resources after each test."""


### PR DESCRIPTION
## Summary
- add `TestWhenPrinting` base class with queue/history/media setup and helper methods
- convert all JPEG tests to inherit from the new base class
- package `jpeg_nuevo` and subfolders for reliable imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for 'dunetuf')*

------
https://chatgpt.com/codex/tasks/task_e_686e9e893244833293cc8be90783c78a