### PR TITLE
Add pwg_new tests

### DIFF
--- a/pwg_new/test_when_printing_pwg_a4_600x8_color_1_page_sim.py
+++ b/pwg_new/test_when_printing_pwg_a4_600x8_color_1_page_sim.py
@@ -1,0 +1,74 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg a4 600x8 color one page from *a4-600x8-color-1p-sim.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:180
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:a4-600x8-color-1p-sim.pwg=a1ebe561325c2b4764cb55cbfdde3a3ed7907bd44f16760ee34523d7861a2a1a
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_a4_600x8_color_1_page_sim_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_a4_600x8_color_one_page
+        +guid:f278ec25-4945-4a26-9082-c16d8ae5f95a
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_a4_600x8_color_1_page_sim_file_then_succeeds(self):
+
+        default_tray = self.media.get_default_source()
+        media_sizes = self.media.get_media_sizes(default_tray)
+        if self.media.MediaSize.A4 in media_sizes:
+            self.media.tray.load(default_tray, self.media.MediaSize.A4, self.media.MediaType.Plain)
+
+        job_id = self.print.raw.start('a1ebe561325c2b4764cb55cbfdde3a3ed7907bd44f16760ee34523d7861a2a1a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_a4_600x8_mono_1_page_sim.py
+++ b/pwg_new/test_when_printing_pwg_a4_600x8_mono_1_page_sim.py
@@ -1,0 +1,81 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg a4 600x8 mono one page from *a4-600x8-mono-1p-sim.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:180
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:a4-600x8-mono-1p-sim.pwg=706dc4ec7cc7102294bd874d627301bbbb8e84c18378528ffd59ba63639f1697
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_a4_600x8_mono_1_page_sim_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_a4_600x8_mono_one_page
+        +guid:66ea988b-2d8a-4a0c-bf7c-f35a03f90b1e
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+    +overrides:
+        +Home:
+            +is_manual:False
+            +timeout:360
+            +test:
+                +dut:
+                    +type:Engine
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_a4_600x8_mono_1_page_sim_file_then_succeeds(self):
+
+        default_tray = self.media.get_default_source()
+        media_sizes = self.media.get_media_sizes(default_tray)
+        if self.media.MediaSize.A4 in media_sizes:
+            self.media.tray.load(default_tray, self.media.MediaSize.A4, self.media.MediaType.Plain)
+
+        job_id = self.print.raw.start('706dc4ec7cc7102294bd874d627301bbbb8e84c18378528ffd59ba63639f1697')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_a4_clip_inside_1_page.py
+++ b/pwg_new/test_when_printing_pwg_a4_clip_inside_1_page.py
@@ -1,0 +1,68 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg a4 job with margin layout as clip inside
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:180
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:ClipInside_WSD.prn=fa41dfb8b75d165644446618818135dcdcf835d6abb595b087c8b663aae8b6af
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_a4_clip_inside_1_page_file_then_succeeds
+    +test:
+        +title:test_pwg_a4_clip_inside_1_page
+        +guid:88bbeb64-ef81-4e74-bb63-7c5e82f8f38d
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_a4_clip_inside_1_page_file_then_succeeds(self):
+
+        self.outputsaver.validate_crc_tiff()
+        default_tray = self.media.get_default_source()
+        media_sizes = self.media.get_media_sizes(default_tray)
+        if self.media.MediaSize.A4 in media_sizes:
+            self.media.tray.load(default_tray, self.media.MediaSize.A4, self.media.MediaType.Plain)
+
+        job_id = self.print.raw.start('fa41dfb8b75d165644446618818135dcdcf835d6abb595b087c8b663aae8b6af')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_media_select_by_page_size_1.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_media_select_by_page_size_1.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-MediaSelectByPageSize-1.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-MediaSelectByPageSize-1.pwg=597eedc2a441e20568af95325af85a182f06d496c851092703dfd3b9a8d6175d
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_media_select_by_page_size_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_media_select_by_page_size_1
+        +guid:fa9255ac-36ee-4af7-9779-737d3c284943
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_media_select_by_page_size_1_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('597eedc2a441e20568af95325af85a182f06d496c851092703dfd3b9a8d6175d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_media_select_by_page_size_3.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_media_select_by_page_size_3.py
@@ -1,0 +1,75 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg clould print media select by page size by 3 from *PwgCloudPrint-MediaSelectByPageSize-3.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-MediaSelectByPageSize-3.pwg=e07c54607a659835e4bbf1c98feb3496fa5cd8da8f55774cf712942ea13b6806
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_media_select_by_page_size_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_media_select_by_page_size_3
+        +guid:7823344a-5291-422d-9bef-49e17386aa8a
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_media_select_by_page_size_3_file_then_succeeds(self):
+
+        default_tray = self.media.get_default_source()
+        media_sizes = self.media.get_media_sizes(default_tray)
+        if self.media.MediaSize.A4 in media_sizes:
+            self.media.tray.load(default_tray, self.media.MediaSize.A4, self.media.MediaType.Stationery)
+
+        job_id = self.print.raw.start('e07c54607a659835e4bbf1c98feb3496fa5cd8da8f55774cf712942ea13b6806')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_1.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_1.py
@@ -1,0 +1,72 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-1.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-1.pwg=acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_1
+        +guid:375a6662-08cf-400b-9f36-35310b77334a
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_1_file_then_succeeds(self):
+
+        self.outputsaver.operation_mode('TIFF')
+        job_id = self.print.raw.start('acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_2.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_2.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-2.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-2.pwg=555c7a547d698ada566577a22253818e0dcc29fb8bdfaad1e41671f72f7bb9b2
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_2_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_2
+        +guid:ab0dd3eb-547d-4da9-894a-4354b0846824
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_2_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('555c7a547d698ada566577a22253818e0dcc29fb8bdfaad1e41671f72f7bb9b2')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_3.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_3.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-3.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-3.pwg=0fb7aa66b80a8a3ea9c135bc3c8ac18027e782e93949c84e67aa02482be59009
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_3
+        +guid:72435f24-bbc1-4aaf-b3fd-bf263c3f10aa
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_3_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('0fb7aa66b80a8a3ea9c135bc3c8ac18027e782e93949c84e67aa02482be59009')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_4.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_4.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-4.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-4.pwg=b064f199414211c8dae7aca4cc6db8de9018b714cc4d1d140f093e4ff47a1452
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_4_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_4
+        +guid:0e2effe8-ee23-4ac6-8ad0-1554929806b1
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_4_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('b064f199414211c8dae7aca4cc6db8de9018b714cc4d1d140f093e4ff47a1452')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_5.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_5.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-5.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-5.pwg=a87e49b791aefb8b1971f4f889d51e027dce797e88438a4464189ac9512c1247
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_5_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_5
+        +guid:b8728528-c6fb-4469-96ad-06692d2e2d2b
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_5_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('a87e49b791aefb8b1971f4f889d51e027dce797e88438a4464189ac9512c1247')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_6.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_6.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-6.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-6.pwg=5338e09e0248feec28fe1380760beaff8356fdd9a639a09e5223164d520d77c6
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_6_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_6
+        +guid:9fc6df95-90c0-4d09-ae53-c3e24d9f6d63
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_6_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('5338e09e0248feec28fe1380760beaff8356fdd9a639a09e5223164d520d77c6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_7.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_7.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-7.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-7.pwg=63a133d4d7dbe3a8617f062883851926282580ade180f184233454b97ad808fb
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_7_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_7
+        +guid:22c4a3a8-fd2e-4b4b-9364-4d85d14d4c70
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_7_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('63a133d4d7dbe3a8617f062883851926282580ade180f184233454b97ad808fb')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_8.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_8.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-8.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-8.pwg=914f30ffceeb8c10234eb36c7cfe5f8a2b7d09f7307ac1886bdf91200f0edbbc
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_8_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_8
+        +guid:5f482483-7411-4919-b398-4d91909ceae2
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_8_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('914f30ffceeb8c10234eb36c7cfe5f8a2b7d09f7307ac1886bdf91200f0edbbc')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_9.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_9.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-9.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-9.pwg=cdae98a174527d911696baed0fa8f7832a786104f07539dd05013f917b3127d1
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_9_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_9
+        +guid:23ac898f-a98d-43ed-86ee-86d9f62d9621
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_9_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('cdae98a174527d911696baed0fa8f7832a786104f07539dd05013f917b3127d1')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_print_quality_1.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_print_quality_1.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print - print quality-1 page from *PwgCloudPrint-PrintQuality-1.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-PrintQuality-1.pwg=9ab58207d267317d47a69b3829f15b03f1f05626ae07d0ce3c046dabb11a74ac
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_print_quality_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_print_quality_1
+        +guid:0bea5ecc-9f4b-40d5-b1fd-0a4b334d206d
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_print_quality_1_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('9ab58207d267317d47a69b3829f15b03f1f05626ae07d0ce3c046dabb11a74ac')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_print_quality_2.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_print_quality_2.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print - print quality-2 page from *PwgCloudPrint-PrintQuality-2.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-PrintQuality-2.pwg=81c8acb0e88cbf3367c4e8faf94e349a203d98cf80b2943e18d24adaafbe60dd
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_print_quality_2_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_print_quality_2
+        +guid:d521a2f1-baf5-41cb-8d13-fa36a979a8e0
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_print_quality_2_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('81c8acb0e88cbf3367c4e8faf94e349a203d98cf80b2943e18d24adaafbe60dd')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_print_quality_3.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_print_quality_3.py
@@ -1,0 +1,79 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print-print quality-3 from *PwgCloudPrint-PrintQuality-3.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-PrintQuality-3.pwg=23786946e342d1612d21821f5dfbd747b8be869bbe9b7f053e563c19801f4eb0
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_print_quality_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_print_quality_3
+        +guid:72e21c4b-d832-4232-9bdd-a7f791d0bf26
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_print_quality_3_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('23786946e342d1612d21821f5dfbd747b8be869bbe9b7f053e563c19801f4eb0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_render_intent_1.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_render_intent_1.py
@@ -1,0 +1,76 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print render intent-1 from *PwgCloudPrint-RenderIntent-1.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-RenderIntent-1.pwg=9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_render_intent_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_render_intent_1_page
+        +guid:04b3cd32-f4e2-484e-85e9-9c1f6c3551c9
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+    +overrides:
+        +Home:
+            +is_manual:False
+            +timeout:360
+            +test:
+                +dut:
+                    +type:Engine
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_render_intent_1_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_render_intent_2.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_render_intent_2.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print render intent-2 from *PwgCloudPrint-RenderIntent-2.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-RenderIntent-2.pwg=dd7f181fe6ddc188a0951a2ca052bac60ab64874b7ebff57be9fc6abe316658e
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_render_intent_2_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_render_intent_2_page
+        +guid:87820cb1-38c1-4a62-b40d-6088f55ca974
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_render_intent_2_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('dd7f181fe6ddc188a0951a2ca052bac60ab64874b7ebff57be9fc6abe316658e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_render_intent_3.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_render_intent_3.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print render intent-3 from *PwgCloudPrint-RenderIntent-3.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-RenderIntent-3.pwg=9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_render_intent_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_render_intent_3_page
+        +guid:901f7041-43d5-43f0-b529-c2edefe364dc
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_render_intent_3_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_render_intent_4.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_render_intent_4.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print render intent-4 from *PwgCloudPrint-RenderIntent-4.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-RenderIntent-4.pwg=9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_render_intent_4_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_render_intent_4_page
+        +guid:2e3cd48c-3d5f-4c44-8ea6-1417c049b15b
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_render_intent_4_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_render_intent_5.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_render_intent_5.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print render intent-5 from *PwgCloudPrint-RenderIntent-5.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-RenderIntent-5.pwg=9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_render_intent_5_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_render_intent_5_page
+        +guid:169953c4-fccf-4596-a554-61d62b65dec6
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_render_intent_5_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_render_intent_6.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_render_intent_6.py
@@ -1,0 +1,79 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print render intent-6 from *PwgCloudPrint-RenderIntent-6.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-RenderIntent-6.pwg=9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_render_intent_6_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_render_intent_6_page
+        +guid:44daa7b3-5163-4c72-8a41-6e08ed473e80
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_render_intent_6_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_1.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_1.py
@@ -1,0 +1,79 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-1 from *PwgCloudPrint-ResUpScalePhase2-1.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-1.pwg=449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_1_page
+        +guid:cc550fd2-d192-4763-990b-b328503b10f8
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_1_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_10.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_10.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-10 from *PwgCloudPrint-ResUpScalePhase2-10.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-10.pwg=2db8056eefa5a72b885e76181720b013f14a4fce311cc76acb008d2e71e51cc6
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_10_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_10_page
+        +guid:9e29acea-ad40-4da4-877a-75b1bac52e83
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_10_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('2db8056eefa5a72b885e76181720b013f14a4fce311cc76acb008d2e71e51cc6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_11.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_11.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-11 from *PwgCloudPrint-ResUpScalePhase2-11.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-11.pwg=b183486585196e3b50bf96c0a3e0ed9d6b4fce16a7217142890faa0566e13f53
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_11_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_11_page
+        +guid:2da2bfae-6696-4f38-a978-89b586f7d05e
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_11_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('b183486585196e3b50bf96c0a3e0ed9d6b4fce16a7217142890faa0566e13f53')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_12.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_12.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-12 from *PwgCloudPrint-ResUpScalePhase2-12.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-12.pwg=5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_12_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_12_page
+        +guid:04f64241-3dfc-4da2-8038-817d667a451b
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_12_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_13.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_13.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-13 from *PwgCloudPrint-ResUpScalePhase2-13.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-13.pwg=449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_13_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_13_page
+        +guid:07df1d6d-66d2-4ed0-b314-5140b97b003d
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_13_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_14.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_14.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-14 from *PwgCloudPrint-ResUpScalePhase2-14.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-14.pwg=5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_14_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_14_page
+        +guid:6f8538bb-af8a-42d8-b237-b33f99ff5f93
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_14_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_15.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_15.py
@@ -1,0 +1,79 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-15 from *PwgCloudPrint-ResUpScalePhase2-15.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-15.pwg=acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_15_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_15_page
+        +guid:2e7e2d80-9e5a-4f12-bc08-366c473fb5ef
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_15_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"


### PR DESCRIPTION
## Summary
- add pwg_new folder with 30 refactored tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dunetuf')*

------
https://chatgpt.com/codex/tasks/task_e_6880daa2cb008332a7ba632de842b9ea