### PR TITLE
Add pwg_new tests part 3

### DIFF
--- a/pwg_new/test_when_printing_pwg_a4_600x8_color_1_page_sim.py
+++ b/pwg_new/test_when_printing_pwg_a4_600x8_color_1_page_sim.py
@@ -1,0 +1,74 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg a4 600x8 color one page from *a4-600x8-color-1p-sim.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:180
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:a4-600x8-color-1p-sim.pwg=a1ebe561325c2b4764cb55cbfdde3a3ed7907bd44f16760ee34523d7861a2a1a
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_a4_600x8_color_1_page_sim_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_a4_600x8_color_one_page
+        +guid:f278ec25-4945-4a26-9082-c16d8ae5f95a
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_a4_600x8_color_1_page_sim_file_then_succeeds(self):
+
+        default_tray = self.media.get_default_source()
+        media_sizes = self.media.get_media_sizes(default_tray)
+        if self.media.MediaSize.A4 in media_sizes:
+            self.media.tray.load(default_tray, self.media.MediaSize.A4, self.media.MediaType.Plain)
+
+        job_id = self.print.raw.start('a1ebe561325c2b4764cb55cbfdde3a3ed7907bd44f16760ee34523d7861a2a1a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_a4_600x8_mono_1_page_sim.py
+++ b/pwg_new/test_when_printing_pwg_a4_600x8_mono_1_page_sim.py
@@ -1,0 +1,81 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg a4 600x8 mono one page from *a4-600x8-mono-1p-sim.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:180
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:a4-600x8-mono-1p-sim.pwg=706dc4ec7cc7102294bd874d627301bbbb8e84c18378528ffd59ba63639f1697
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_a4_600x8_mono_1_page_sim_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_a4_600x8_mono_one_page
+        +guid:66ea988b-2d8a-4a0c-bf7c-f35a03f90b1e
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+    +overrides:
+        +Home:
+            +is_manual:False
+            +timeout:360
+            +test:
+                +dut:
+                    +type:Engine
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_a4_600x8_mono_1_page_sim_file_then_succeeds(self):
+
+        default_tray = self.media.get_default_source()
+        media_sizes = self.media.get_media_sizes(default_tray)
+        if self.media.MediaSize.A4 in media_sizes:
+            self.media.tray.load(default_tray, self.media.MediaSize.A4, self.media.MediaType.Plain)
+
+        job_id = self.print.raw.start('706dc4ec7cc7102294bd874d627301bbbb8e84c18378528ffd59ba63639f1697')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_a4_clip_inside_1_page.py
+++ b/pwg_new/test_when_printing_pwg_a4_clip_inside_1_page.py
@@ -1,0 +1,68 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg a4 job with margin layout as clip inside
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:180
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:ClipInside_WSD.prn=fa41dfb8b75d165644446618818135dcdcf835d6abb595b087c8b663aae8b6af
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_a4_clip_inside_1_page_file_then_succeeds
+    +test:
+        +title:test_pwg_a4_clip_inside_1_page
+        +guid:88bbeb64-ef81-4e74-bb63-7c5e82f8f38d
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_a4_clip_inside_1_page_file_then_succeeds(self):
+
+        self.outputsaver.validate_crc_tiff()
+        default_tray = self.media.get_default_source()
+        media_sizes = self.media.get_media_sizes(default_tray)
+        if self.media.MediaSize.A4 in media_sizes:
+            self.media.tray.load(default_tray, self.media.MediaSize.A4, self.media.MediaType.Plain)
+
+        job_id = self.print.raw.start('fa41dfb8b75d165644446618818135dcdcf835d6abb595b087c8b663aae8b6af')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_media_select_by_page_size_1.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_media_select_by_page_size_1.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-MediaSelectByPageSize-1.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-MediaSelectByPageSize-1.pwg=597eedc2a441e20568af95325af85a182f06d496c851092703dfd3b9a8d6175d
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_media_select_by_page_size_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_media_select_by_page_size_1
+        +guid:fa9255ac-36ee-4af7-9779-737d3c284943
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_media_select_by_page_size_1_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('597eedc2a441e20568af95325af85a182f06d496c851092703dfd3b9a8d6175d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_media_select_by_page_size_3.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_media_select_by_page_size_3.py
@@ -1,0 +1,75 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg clould print media select by page size by 3 from *PwgCloudPrint-MediaSelectByPageSize-3.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-MediaSelectByPageSize-3.pwg=e07c54607a659835e4bbf1c98feb3496fa5cd8da8f55774cf712942ea13b6806
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_media_select_by_page_size_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_media_select_by_page_size_3
+        +guid:7823344a-5291-422d-9bef-49e17386aa8a
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_media_select_by_page_size_3_file_then_succeeds(self):
+
+        default_tray = self.media.get_default_source()
+        media_sizes = self.media.get_media_sizes(default_tray)
+        if self.media.MediaSize.A4 in media_sizes:
+            self.media.tray.load(default_tray, self.media.MediaSize.A4, self.media.MediaType.Stationery)
+
+        job_id = self.print.raw.start('e07c54607a659835e4bbf1c98feb3496fa5cd8da8f55774cf712942ea13b6806')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_1.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_1.py
@@ -1,0 +1,72 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-1.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-1.pwg=acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_1
+        +guid:375a6662-08cf-400b-9f36-35310b77334a
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_1_file_then_succeeds(self):
+
+        self.outputsaver.operation_mode('TIFF')
+        job_id = self.print.raw.start('acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_2.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_2.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-2.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-2.pwg=555c7a547d698ada566577a22253818e0dcc29fb8bdfaad1e41671f72f7bb9b2
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_2_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_2
+        +guid:ab0dd3eb-547d-4da9-894a-4354b0846824
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_2_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('555c7a547d698ada566577a22253818e0dcc29fb8bdfaad1e41671f72f7bb9b2')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_3.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_3.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-3.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-3.pwg=0fb7aa66b80a8a3ea9c135bc3c8ac18027e782e93949c84e67aa02482be59009
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_3
+        +guid:72435f24-bbc1-4aaf-b3fd-bf263c3f10aa
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_3_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('0fb7aa66b80a8a3ea9c135bc3c8ac18027e782e93949c84e67aa02482be59009')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_4.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_4.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-4.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-4.pwg=b064f199414211c8dae7aca4cc6db8de9018b714cc4d1d140f093e4ff47a1452
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_4_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_4
+        +guid:0e2effe8-ee23-4ac6-8ad0-1554929806b1
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_4_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('b064f199414211c8dae7aca4cc6db8de9018b714cc4d1d140f093e4ff47a1452')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_5.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_5.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-5.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-5.pwg=a87e49b791aefb8b1971f4f889d51e027dce797e88438a4464189ac9512c1247
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_5_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_5
+        +guid:b8728528-c6fb-4469-96ad-06692d2e2d2b
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_5_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('a87e49b791aefb8b1971f4f889d51e027dce797e88438a4464189ac9512c1247')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_6.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_6.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-6.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-6.pwg=5338e09e0248feec28fe1380760beaff8356fdd9a639a09e5223164d520d77c6
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_6_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_6
+        +guid:9fc6df95-90c0-4d09-ae53-c3e24d9f6d63
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_6_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('5338e09e0248feec28fe1380760beaff8356fdd9a639a09e5223164d520d77c6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_7.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_7.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-7.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-7.pwg=63a133d4d7dbe3a8617f062883851926282580ade180f184233454b97ad808fb
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_7_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_7
+        +guid:22c4a3a8-fd2e-4b4b-9364-4d85d14d4c70
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_7_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('63a133d4d7dbe3a8617f062883851926282580ade180f184233454b97ad808fb')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_8.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_8.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-8.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-8.pwg=914f30ffceeb8c10234eb36c7cfe5f8a2b7d09f7307ac1886bdf91200f0edbbc
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_8_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_8
+        +guid:5f482483-7411-4919-b398-4d91909ceae2
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_8_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('914f30ffceeb8c10234eb36c7cfe5f8a2b7d09f7307ac1886bdf91200f0edbbc')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_orientation_9.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_orientation_9.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgCloudPrint-Orientation-9.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-Orientation-9.pwg=cdae98a174527d911696baed0fa8f7832a786104f07539dd05013f917b3127d1
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_orientation_9_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_orientation_9
+        +guid:23ac898f-a98d-43ed-86ee-86d9f62d9621
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_orientation_9_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('cdae98a174527d911696baed0fa8f7832a786104f07539dd05013f917b3127d1')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_print_quality_1.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_print_quality_1.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print - print quality-1 page from *PwgCloudPrint-PrintQuality-1.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-PrintQuality-1.pwg=9ab58207d267317d47a69b3829f15b03f1f05626ae07d0ce3c046dabb11a74ac
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_print_quality_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_print_quality_1
+        +guid:0bea5ecc-9f4b-40d5-b1fd-0a4b334d206d
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_print_quality_1_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('9ab58207d267317d47a69b3829f15b03f1f05626ae07d0ce3c046dabb11a74ac')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_print_quality_2.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_print_quality_2.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print - print quality-2 page from *PwgCloudPrint-PrintQuality-2.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-PrintQuality-2.pwg=81c8acb0e88cbf3367c4e8faf94e349a203d98cf80b2943e18d24adaafbe60dd
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_print_quality_2_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_print_quality_2
+        +guid:d521a2f1-baf5-41cb-8d13-fa36a979a8e0
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_print_quality_2_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('81c8acb0e88cbf3367c4e8faf94e349a203d98cf80b2943e18d24adaafbe60dd')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_print_quality_3.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_print_quality_3.py
@@ -1,0 +1,79 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print-print quality-3 from *PwgCloudPrint-PrintQuality-3.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-PrintQuality-3.pwg=23786946e342d1612d21821f5dfbd747b8be869bbe9b7f053e563c19801f4eb0
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_print_quality_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_print_quality_3
+        +guid:72e21c4b-d832-4232-9bdd-a7f791d0bf26
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_print_quality_3_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('23786946e342d1612d21821f5dfbd747b8be869bbe9b7f053e563c19801f4eb0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_render_intent_1.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_render_intent_1.py
@@ -1,0 +1,76 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print render intent-1 from *PwgCloudPrint-RenderIntent-1.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-RenderIntent-1.pwg=9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_render_intent_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_render_intent_1_page
+        +guid:04b3cd32-f4e2-484e-85e9-9c1f6c3551c9
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+    +overrides:
+        +Home:
+            +is_manual:False
+            +timeout:360
+            +test:
+                +dut:
+                    +type:Engine
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_render_intent_1_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_render_intent_2.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_render_intent_2.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print render intent-2 from *PwgCloudPrint-RenderIntent-2.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-RenderIntent-2.pwg=dd7f181fe6ddc188a0951a2ca052bac60ab64874b7ebff57be9fc6abe316658e
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_render_intent_2_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_render_intent_2_page
+        +guid:87820cb1-38c1-4a62-b40d-6088f55ca974
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_render_intent_2_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('dd7f181fe6ddc188a0951a2ca052bac60ab64874b7ebff57be9fc6abe316658e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_render_intent_3.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_render_intent_3.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print render intent-3 from *PwgCloudPrint-RenderIntent-3.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-RenderIntent-3.pwg=9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_render_intent_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_render_intent_3_page
+        +guid:901f7041-43d5-43f0-b529-c2edefe364dc
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_render_intent_3_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_render_intent_4.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_render_intent_4.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print render intent-4 from *PwgCloudPrint-RenderIntent-4.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-RenderIntent-4.pwg=9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_render_intent_4_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_render_intent_4_page
+        +guid:2e3cd48c-3d5f-4c44-8ea6-1417c049b15b
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_render_intent_4_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_render_intent_5.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_render_intent_5.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print render intent-5 from *PwgCloudPrint-RenderIntent-5.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-RenderIntent-5.pwg=9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_render_intent_5_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_render_intent_5_page
+        +guid:169953c4-fccf-4596-a554-61d62b65dec6
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_render_intent_5_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_render_intent_6.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_render_intent_6.py
@@ -1,0 +1,79 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print render intent-6 from *PwgCloudPrint-RenderIntent-6.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-RenderIntent-6.pwg=9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_render_intent_6_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_render_intent_6_page
+        +guid:44daa7b3-5163-4c72-8a41-6e08ed473e80
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_render_intent_6_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('9e2aacf9b339519a93db7657921de351642653776b93885fa81656319fc689fa')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_1.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_1.py
@@ -1,0 +1,79 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-1 from *PwgCloudPrint-ResUpScalePhase2-1.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-1.pwg=449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_1_page
+        +guid:cc550fd2-d192-4763-990b-b328503b10f8
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_1_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_10.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_10.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-10 from *PwgCloudPrint-ResUpScalePhase2-10.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-10.pwg=2db8056eefa5a72b885e76181720b013f14a4fce311cc76acb008d2e71e51cc6
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_10_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_10_page
+        +guid:9e29acea-ad40-4da4-877a-75b1bac52e83
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_10_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('2db8056eefa5a72b885e76181720b013f14a4fce311cc76acb008d2e71e51cc6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_11.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_11.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-11 from *PwgCloudPrint-ResUpScalePhase2-11.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-11.pwg=b183486585196e3b50bf96c0a3e0ed9d6b4fce16a7217142890faa0566e13f53
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_11_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_11_page
+        +guid:2da2bfae-6696-4f38-a978-89b586f7d05e
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_11_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('b183486585196e3b50bf96c0a3e0ed9d6b4fce16a7217142890faa0566e13f53')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_12.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_12.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-12 from *PwgCloudPrint-ResUpScalePhase2-12.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-12.pwg=5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_12_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_12_page
+        +guid:04f64241-3dfc-4da2-8038-817d667a451b
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_12_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_13.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_13.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-13 from *PwgCloudPrint-ResUpScalePhase2-13.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-13.pwg=449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_13_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_13_page
+        +guid:07df1d6d-66d2-4ed0-b314-5140b97b003d
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_13_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_14.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_14.py
@@ -1,0 +1,70 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-14 from *PwgCloudPrint-ResUpScalePhase2-14.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-14.pwg=5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_14_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_14_page
+        +guid:6f8538bb-af8a-42d8-b237-b33f99ff5f93
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_14_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_15.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_15.py
@@ -1,0 +1,79 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-15 from *PwgCloudPrint-ResUpScalePhase2-15.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-15.pwg=acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_15_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_15_page
+        +guid:2e7e2d80-9e5a-4f12-bc08-366c473fb5ef
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_15_file_then_succeeds(self):
+
+        job_id = self.print.raw.start('acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_2.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_2.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-6 from *PwgCloudPrint-ResUpScalePhase2-2.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-2.pwg=449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_2_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_2_page
+        +guid:40b4c057-2972-4707-8911-acdac5f7371a
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_2_file_then_succeeds(self):
+        job_id = self.print.raw.start('449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_3.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_3.py
@@ -1,0 +1,72 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-3 from *PwgCloudPrint-ResUpScalePhase2-3.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-3.pwg=449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_3_page
+        +guid:19e61f37-98f6-4ea4-b371-2d8eaa6229c4
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_3_file_then_succeeds(self):
+
+        self.outputsaver.operation_mode('TIFF')
+        job_id = self.print.raw.start('449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_4.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_4.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-4 from *PwgCloudPrint-ResUpScalePhase2-4.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-4.pwg=b183486585196e3b50bf96c0a3e0ed9d6b4fce16a7217142890faa0566e13f53
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_4_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_4_page
+        +guid:b277ba65-6e7a-4f54-a43d-bb996d946c47
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_4_file_then_succeeds(self):
+        job_id = self.print.raw.start('b183486585196e3b50bf96c0a3e0ed9d6b4fce16a7217142890faa0566e13f53')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_5.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_5.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-5 from *PwgCloudPrint-ResUpScalePhase2-5.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-5.pwg=b183486585196e3b50bf96c0a3e0ed9d6b4fce16a7217142890faa0566e13f53
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_5_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_5_page
+        +guid:a3551f56-636c-4a3e-a481-a45b6dcbfd5c
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_5_file_then_succeeds(self):
+        job_id = self.print.raw.start('b183486585196e3b50bf96c0a3e0ed9d6b4fce16a7217142890faa0566e13f53')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_6.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_6.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-6 from *PwgCloudPrint-ResUpScalePhase2-6.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-6.pwg=b183486585196e3b50bf96c0a3e0ed9d6b4fce16a7217142890faa0566e13f53
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_6_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_6_page
+        +guid:36bd8007-a134-47ee-9a69-48b2ff813223
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_6_file_then_succeeds(self):
+        job_id = self.print.raw.start('b183486585196e3b50bf96c0a3e0ed9d6b4fce16a7217142890faa0566e13f53')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_7.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_7.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-7 from *PwgCloudPrint-ResUpScalePhase2-7.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-7.pwg=acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_7_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_7_page
+        +guid:4e1699c0-d26c-4fc8-a916-fbe75b82135b
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_7_file_then_succeeds(self):
+        job_id = self.print.raw.start('acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_8.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_8.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-8 from *PwgCloudPrint-ResUpScalePhase2-8.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-8.pwg=449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_8_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_8_page
+        +guid:85dcd754-9865-4b52-b7d7-bec213f54cf6
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_8_file_then_succeeds(self):
+        job_id = self.print.raw.start('449c80c848e1cff57c4e1e58defc551459c69e2643ccd95cebb6b5e8aa9557cd')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_9.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_resolution_up_scale_phase2_9.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print resolution up scale phase2-9 from *PwgCloudPrint-ResUpScalePhase2-9.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ResUpScalePhase2-9.pwg=50d88787aa538037aef45624809af6b332ebb41a2fa0310eb1ea5c5e4b43f69d
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_resolution_up_scale_phase2_9_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_resolution_up_scale_phase2_9_page
+        +guid:41d19d4f-8147-4df5-8113-64f2f65fc190
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_resolution_up_scale_phase2_9_file_then_succeeds(self):
+        job_id = self.print.raw.start('50d88787aa538037aef45624809af6b332ebb41a2fa0310eb1ea5c5e4b43f69d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_1.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_1.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print-valid raster format-1 page from *PwgCloudPrint-ValidRasterFormat-1.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-1.pwg=9aa53ec78858441d7becdc848adc595240164d5e5169ca6d18112a612b1efdd9
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_1_page
+        +guid:c65a6eb8-e046-4b07-a0c1-f8f13dae66fc
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_1_file_then_succeeds(self):
+        job_id = self.print.raw.start('9aa53ec78858441d7becdc848adc595240164d5e5169ca6d18112a612b1efdd9')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_10.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_10.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print-valid raster format-10 page from *PwgCloudPrint-ValidRasterFormat-10.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-10.pwg=9aa53ec78858441d7becdc848adc595240164d5e5169ca6d18112a612b1efdd9
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_10_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_10_page
+        +guid:9b0606b6-faad-4738-a043-05b99bb3da99
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_10_file_then_succeeds(self):
+        job_id = self.print.raw.start('9aa53ec78858441d7becdc848adc595240164d5e5169ca6d18112a612b1efdd9')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_11.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_11.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print-valid raster format-11 page from *PwgCloudPrint-ValidRasterFormat-11.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-11.pwg=9aa53ec78858441d7becdc848adc595240164d5e5169ca6d18112a612b1efdd9
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_11_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_11_page
+        +guid:18202201-7d12-421a-adda-d487f7418037
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_11_file_then_succeeds(self):
+        job_id = self.print.raw.start('9aa53ec78858441d7becdc848adc595240164d5e5169ca6d18112a612b1efdd9')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_12.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_12.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print-valid raster format-12 page from *PwgCloudPrint-ValidRasterFormat-12.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:300
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-12.pwg=5513c79efb88892bab44579d5f332704c199f9fc72112eb65695ec24f64210e0
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_12_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_12_page
+        +guid:c5c195f7-8854-4f2b-8fa0-478b9f3f255d
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_12_file_then_succeeds(self):
+        job_id = self.print.raw.start('5513c79efb88892bab44579d5f332704c199f9fc72112eb65695ec24f64210e0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_13.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_13.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print-valid raster format-13 page from *PwgCloudPrint-ValidRasterFormat-13.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-13.pwg=5513c79efb88892bab44579d5f332704c199f9fc72112eb65695ec24f64210e0
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_13_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_13_page
+        +guid:3c954748-017e-439f-b54c-c2d44963a445
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_13_file_then_succeeds(self):
+        job_id = self.print.raw.start('5513c79efb88892bab44579d5f332704c199f9fc72112eb65695ec24f64210e0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_14.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_14.py
@@ -1,0 +1,78 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print valid raster format-14 from *PwgCloudPrint-ValidRasterFormat-14.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-14.pwg=025049c3f5ed5bf7914b36257e6b74a13939a0305585d017abf7dbe3f7144521
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_14_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_14_page
+        +guid:8755a40c-33fe-46e6-9143-818f2a2a46a4
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_14_file_then_succeeds(self):
+        job_id = self.print.raw.start('025049c3f5ed5bf7914b36257e6b74a13939a0305585d017abf7dbe3f7144521')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_15.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_15.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print valid raster format-15 from *PwgCloudPrint-ValidRasterFormat-15.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-15.pwg=025049c3f5ed5bf7914b36257e6b74a13939a0305585d017abf7dbe3f7144521
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_15_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_15_page
+        +guid:141575c4-e3bd-40af-bbe2-a30d667a7275
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_15_file_then_succeeds(self):
+        job_id = self.print.raw.start('025049c3f5ed5bf7914b36257e6b74a13939a0305585d017abf7dbe3f7144521')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_16.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_16.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print valid raster format-16 from *PwgCloudPrint-ValidRasterFormat-16.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-16.pwg=acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_16_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_16_page
+        +guid:528a9244-7dd6-4ee4-8f7a-a5484f280d44
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_16_file_then_succeeds(self):
+        job_id = self.print.raw.start('acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_17.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_17.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print valid raster format-17 from *PwgCloudPrint-ValidRasterFormat-17.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-17.pwg=7d2697f8462c3f412fa0fd82b2476b683792079f551029f6ee4d2277ac4b8601
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_17_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_17_page
+        +guid:8156a335-a56b-40c1-8c4c-e45f229dbb0f
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_17_file_then_succeeds(self):
+        job_id = self.print.raw.start('7d2697f8462c3f412fa0fd82b2476b683792079f551029f6ee4d2277ac4b8601')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_18.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_18.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print valid raster format-18 from *PwgCloudPrint-ValidRasterFormat-18.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-18.pwg=acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_18_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_18_page
+        +guid:b5142e95-fdb9-4265-b550-8d1866f67e8d
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_18_file_then_succeeds(self):
+        job_id = self.print.raw.start('acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_19.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_19.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print-valid raster format-19 page from *PwgCloudPrint-ValidRasterFormat-19.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-19.pwg=7cca926b733b1e78d298a3d558b45df5137b49fff3de1c7906a724c55a5d038b
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_19_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_19_page
+        +guid:be2cdcd9-960f-4c98-90fb-f20329e555b5
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster & PrintResolution=Print300
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_19_file_then_succeeds(self):
+        job_id = self.print.raw.start('7cca926b733b1e78d298a3d558b45df5137b49fff3de1c7906a724c55a5d038b')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_2.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_2.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print-valid raster format-2 page from *PwgCloudPrint-ValidRasterFormat-2.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-2.pwg=378e3b9575c76d1176cca9d752b3bb8fda19a208cc663a2da8dd191824bb00a9
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_2_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_2_page
+        +guid:070a237d-6e8a-42aa-a6f8-60e87ac33fed
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_2_file_then_succeeds(self):
+        job_id = self.print.raw.start('378e3b9575c76d1176cca9d752b3bb8fda19a208cc663a2da8dd191824bb00a9')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_20.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_20.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print-valid raster format-20 page from *PwgCloudPrint-ValidRasterFormat-20.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-20.pwg=2db8056eefa5a72b885e76181720b013f14a4fce311cc76acb008d2e71e51cc6
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_20_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_20_page
+        +guid:f39a990a-3f60-465e-aa48-76917a9336d6
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_20_file_then_succeeds(self):
+        job_id = self.print.raw.start('2db8056eefa5a72b885e76181720b013f14a4fce311cc76acb008d2e71e51cc6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_21.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_21.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print valid raster format-21 from *PwgCloudPrint-ValidRasterFormat-21.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-21.pwg=5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_21_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_21_page
+        +guid:8cb6f0a3-2842-4532-b099-42501e9df343
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_21_file_then_succeeds(self):
+        job_id = self.print.raw.start('5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_22.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_22.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print valid raster format-22 from *PwgCloudPrint-ValidRasterFormat-22.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-22.pwg=acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_22_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_22_page
+        +guid:9cc2894b-bed7-4826-b192-eb5103100dbd
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_22_file_then_succeeds(self):
+        job_id = self.print.raw.start('acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_3.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_3.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print-valid raster format-3 page from *PwgCloudPrint-ValidRasterFormat-3.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-3.pwg=2db8056eefa5a72b885e76181720b013f14a4fce311cc76acb008d2e71e51cc6
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_3_page
+        +guid:5abacfa9-9537-43a6-a865-e7fc9034c4db
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_3_file_then_succeeds(self):
+        job_id = self.print.raw.start('2db8056eefa5a72b885e76181720b013f14a4fce311cc76acb008d2e71e51cc6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_4.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_4.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print-valid raster format-4 page from *PwgCloudPrint-ValidRasterFormat-4.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-4.pwg=2db8056eefa5a72b885e76181720b013f14a4fce311cc76acb008d2e71e51cc6
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_4_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_4_page
+        +guid:b363ab61-b587-4480-b099-21a67b599237
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_4_file_then_succeeds(self):
+        job_id = self.print.raw.start('2db8056eefa5a72b885e76181720b013f14a4fce311cc76acb008d2e71e51cc6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_5.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_5.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print valid raster format-5 from *PwgCloudPrint-ValidRasterFormat-5.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-5.pwg=5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_5_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_5_page
+        +guid:1588689f-728b-4382-b3b1-dfc4abd063e8
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_5_file_then_succeeds(self):
+        job_id = self.print.raw.start('5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_6.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_6.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print valid raster format-6 from *PwgCloudPrint-ValidRasterFormat-6.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-6.pwg=5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_6_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_6_page
+        +guid:e61363ce-c922-4d0a-aff9-8db9136be8c1
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_6_file_then_succeeds(self):
+        job_id = self.print.raw.start('5a668918f267a0b9bd150cce07aa4b35a8e042a97f590deaa8828ef41c90d39e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_7.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_7.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print valid raster format-7 from *PwgCloudPrint-ValidRasterFormat-7.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-7.pwg=acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_7_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_7_page
+        +guid:00b72a22-a5ac-48bd-a5bc-7952e084faa6
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_7_file_then_succeeds(self):
+        job_id = self.print.raw.start('acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_8.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_8.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print valid raster format-8 from *PwgCloudPrint-ValidRasterFormat-8.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-8.pwg=acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_8_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_8_page
+        +guid:c06a0ba4-cbe8-494f-a9ce-ee31e84a1e2b
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_8_file_then_succeeds(self):
+        job_id = self.print.raw.start('acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_9.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_valid_raster_format_9.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print valid raster format-9 from *PwgCloudPrint-ValidRasterFormat-9.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-ValidRasterFormat-9.pwg=acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_valid_raster_format_9_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_valid_raster_format_9_page
+        +guid:8eb7e3e4-fad7-4c08-93d8-a55cb5661214
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$
+    """
+    def test_when_using_pwg_cloud_print_valid_raster_format_9_file_then_succeeds(self):
+        job_id = self.print.raw.start('acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_wxh_bitmap_1.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_wxh_bitmap_1.py
@@ -1,0 +1,71 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print WxHBitmap-1 page from *PwgCloudPrint-WxHBitmap-1.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-WxHBitmap-1.pwg=f9d53207963887fac374d5f173a385f701e39bf5a03906374d7ec78750389962
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_wxh_bitmap_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_wxh_bitmap_1_page
+        +guid:bfec753a-5844-4a70-8d89-1531111b0972
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_cloud_print_wxh_bitmap_1_file_then_succeeds(self):
+        default_tray = self.media.get_default_source()
+        media_sizes = self.media.get_media_sizes(default_tray)
+        if self.media.MediaSize.A4 in media_sizes:
+            self.media.tray.load(default_tray, self.media.MediaSize.A4, self.media.MediaType.Plain)
+        job_id = self.print.raw.start('f9d53207963887fac374d5f173a385f701e39bf5a03906374d7ec78750389962')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_cloud_print_wxh_bitmap_3.py
+++ b/pwg_new/test_when_printing_pwg_cloud_print_wxh_bitmap_3.py
@@ -1,0 +1,76 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg cloud print WxHBitmap-3 page from *PwgCloudPrint-WxHBitmap-3.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgCloudPrint-WxHBitmap-3.pwg=a3578b546236e92198317781b29f07fb358cd8c25f68476b9739b6b2de8f1ef9
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_cloud_print_wxh_bitmap_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_cloud_print_wxh_bitmap_3_page
+        +guid:44dbb260-b30a-4b12-888a-5a3597ca40cc
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_cloud_print_wxh_bitmap_3_file_then_succeeds(self):
+        job_id = self.print.raw.start('a3578b546236e92198317781b29f07fb358cd8c25f68476b9739b6b2de8f1ef9')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_first_print_raster.py
+++ b/pwg_new/test_when_printing_pwg_first_print_raster.py
@@ -1,0 +1,76 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg first raster page from *FirstPrint_raster.Pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-11790
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:FirstPrint_raster.Pwg=84f172821aaf4871fce1b21a8a1f8aab6125d683c1fb33816225a01e8aeffce9
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_first_print_raster_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_first_print_raster
+        +guid:0d05300b-f150-424a-ba34-d6722c2dcc00
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_first_print_raster_file_then_succeeds(self):
+        job_id = self.print.raw.start('84f172821aaf4871fce1b21a8a1f8aab6125d683c1fb33816225a01e8aeffce9')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_hs_letter_color_one_page.py
+++ b/pwg_new/test_when_printing_pwg_hs_letter_color_one_page.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg hs_letter_color_one_page *Hs_LTR_Color_1pg.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:LFP_PrintWorkflows
+    +test_framework:TUF
+    +external_files:Hs_LTR_Color_1pg.pwg=6ca956aa09ba67fc5cbf45117681e76bf5022d8bd825e558b85615805ecf3b44
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_hs_letter_color_one_page_file_then_succeeds
+    +test:
+        +title:test_pwg_hs_letter_color_one_page
+        +guid:2fe2f628-a026-48ad-9214-5b15ed79099e
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_hs_letter_color_one_page_file_then_succeeds(self):
+        job_id = self.print.raw.start('6ca956aa09ba67fc5cbf45117681e76bf5022d8bd825e558b85615805ecf3b44')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_letter_600x8_color_2_page_no_4c_sim.py
+++ b/pwg_new/test_when_printing_pwg_letter_600x8_color_2_page_no_4c_sim.py
@@ -1,0 +1,84 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg letter 600x8 color two page no 4C sim from *letter-600x8-color-2pNO4c-sim.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:letter-600x8-color-2pNO4c-sim.pwg=63ac052df55d1e361b86d1aa21a06d21300d0c7c60792ff9c62198ec876a14c2
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_letter_600x8_color_2_page_no_4c_sim_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_letter_600x8_color_two_page_no_4c_sim
+        +guid:9c08e384-b4b7-4a81-9739-6c985d3655f6
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+    +overrides:
+        +Home:
+            +is_manual:False
+            +timeout:360
+            +test:
+                +dut:
+                    +type:Engine
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_letter_600x8_color_2_page_no_4c_sim_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('63ac052df55d1e361b86d1aa21a06d21300d0c7c60792ff9c62198ec876a14c2')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_letter_600x8_color_4_page_duplex.py
+++ b/pwg_new/test_when_printing_pwg_letter_600x8_color_4_page_duplex.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg letter 600x8 color four page duplex from *letter-600x8-color-4p-dup.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:letter-600x8-color-4p-dup.pwg=4046086f1d4058c9519db5d3f32832267305664c66e8c825f1a7b2f179427fdc
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_letter_600x8_color_4_page_duplex_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_letter_600x8_color_four_page_duplex
+        +guid:666d9109-c6b7-4f98-bd55-2e549a5a0d3b
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_letter_600x8_color_4_page_duplex_file_then_succeeds(self):
+        self.outputsaver.operation_mode('TIFF')
+        job_id = self.print.raw.start('4046086f1d4058c9519db5d3f32832267305664c66e8c825f1a7b2f179427fdc')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_letter_600x8_color_4_page_no_duplex.py
+++ b/pwg_new/test_when_printing_pwg_letter_600x8_color_4_page_no_duplex.py
@@ -1,0 +1,78 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg letter 600x8 color four page no duplex from *letter-600x8-color-4p-Nodup.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:letter-600x8-color-4p-NOdup.pwg=76ff895686c9302d166a9e19b9d17ff281a384a4560cdf41d43c7a026a905c0c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_letter_600x8_color_4_page_no_duplex_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_letter_600x8_color_four_page_no_duplex
+        +guid:87b48303-0678-4dc9-b4f8-22af06270f5e
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_letter_600x8_color_4_page_no_duplex_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('76ff895686c9302d166a9e19b9d17ff281a384a4560cdf41d43c7a026a905c0c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_letter_600x8_color_one_page_sim.py
+++ b/pwg_new/test_when_printing_pwg_letter_600x8_color_one_page_sim.py
@@ -1,0 +1,78 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg letter 600X8 color one page from *letter-600x8-color-1p-sim.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:letter-600x8-color-1p-sim.pwg=acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_letter_600x8_color_one_page_sim_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_letter_600X8_color_one_page
+        +guid:2385c0b4-5b65-48e7-a34a-f9edc8edcf31
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_letter_600x8_color_one_page_sim_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('acd1927984e9ed031fc4dac26cbd29112725a05e235b263aa31abdb2465c488c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_letter_600x8_color_two_page_4c_sim.py
+++ b/pwg_new/test_when_printing_pwg_letter_600x8_color_two_page_4c_sim.py
@@ -1,0 +1,76 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg letter 600X8 color two page 4c from *letter-600x8-color-2p4c-sim.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:letter-600x8-color-2p4c-sim.pwg=63ac052df55d1e361b86d1aa21a06d21300d0c7c60792ff9c62198ec876a14c2
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_letter_600x8_color_two_page_4c_sim_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_letter_600X8_color_two_page_4c
+        +guid:f0628476-5d1f-41c0-a0b0-bdcd8d89381e
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_letter_600x8_color_two_page_4c_sim_file_then_succeeds(self):
+        job_id = self.print.raw.start('63ac052df55d1e361b86d1aa21a06d21300d0c7c60792ff9c62198ec876a14c2')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_letter_600x8_mono_one_page_sim.py
+++ b/pwg_new/test_when_printing_pwg_letter_600x8_mono_one_page_sim.py
@@ -1,0 +1,78 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg letter 600X8 mono one page sim page from *letter-600x8-mono-1p-sim.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:letter-600x8-mono-1p-sim.pwg=2db8056eefa5a72b885e76181720b013f14a4fce311cc76acb008d2e71e51cc6
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_letter_600x8_mono_one_page_sim_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_letter_600X8_mono_one_page_sim
+        +guid:80174055-9002-43f1-90de-c6fe41ebc4f7
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_letter_600x8_mono_one_page_sim_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2db8056eefa5a72b885e76181720b013f14a4fce311cc76acb008d2e71e51cc6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_letter_600x8_sgray_one_page.py
+++ b/pwg_new/test_when_printing_pwg_letter_600x8_sgray_one_page.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg letter 600x8 sgray one page from *onepage-letter-sgray-8-600dpi.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-15113
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:onepage-letter-sgray-8-600dpi.pwg=df51655e8f48eead0b875dd30e532ef5f6badacd2caab8b875cd9b2fc3ad1957
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_letter_600x8_sgray_one_page_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_letter_600x8_sgray_one_page
+        +guid:194ec619-c5f6-452e-957e-c908c95ea55e
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_letter_600x8_sgray_one_page_file_then_succeeds(self):
+        self.outputsaver.operation_mode('TIFF')
+        job_id = self.print.raw.start('df51655e8f48eead0b875dd30e532ef5f6badacd2caab8b875cd9b2fc3ad1957')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_mopria_3page_longedge_duplex_portrait.py
+++ b/pwg_new/test_when_printing_pwg_mopria_3page_longedge_duplex_portrait.py
@@ -1,0 +1,75 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PrintPWGRaster3PagesLongEdgeDuplexPortraitUsingMopriaTool.prn
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PrintPWGRaster3PagesLongEdgeDuplexPortraitUsingMopriaTool.prn=7655a24419dd99ad7d72f193c86e40926f1f327d98ad803f97807fdc334e89ac
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_mopria_3page_longedge_duplex_portrait_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_mopria_3page_longedge_duplex_portrait
+        +guid:93f36f08-8223-407d-8809-06d2e3c6b87b
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+    +overrides:
+        +Home:
+            +is_manual:False
+            +timeout:360
+            +test:
+                +dut:
+                    +type:Engine
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_mopria_3page_longedge_duplex_portrait_file_then_succeeds(self):
+        self.outputsaver.operation_mode('TIFF')
+        job_id = self.print.raw.start('7655a24419dd99ad7d72f193c86e40926f1f327d98ad803f97807fdc334e89ac')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_mopria_longedge_duplex_portrait.py
+++ b/pwg_new/test_when_printing_pwg_mopria_longedge_duplex_portrait.py
@@ -1,0 +1,69 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PrintPWGRasterLongEdgeDuplexPortraitUsingMopriaTool.prn
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PrintPWGRasterLongEdgeDuplexPortraitUsingMopriaTool.prn=5fd69b248b6c5b46ca91f748d7538fad5a0371b0551fd9ccd6a5ae44b6e58402
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_mopria_longedge_duplex_portrait_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_mopria_longedge_duplex_portrait
+        +guid:b4139fa3-dac1-414b-938e-368a8fafd2e9
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_mopria_longedge_duplex_portrait_file_then_succeeds(self):
+        self.outputsaver.operation_mode('TIFF')
+        job_id = self.print.raw.start('5fd69b248b6c5b46ca91f748d7538fad5a0371b0551fd9ccd6a5ae44b6e58402')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_mopria_shortedge_duplex_portrait.py
+++ b/pwg_new/test_when_printing_pwg_mopria_shortedge_duplex_portrait.py
@@ -1,0 +1,75 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PrintPWGRasterShortEdgeDuplexPortraitUsingMopriaTool.prn
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PrintPWGRasterShortEdgeDuplexPortraitUsingMopriaTool.prn=5041d4b1512169d0a43d38657fb4181bdb8e0b49209bcdc194617b65e47bbab8
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_mopria_shortedge_duplex_portrait_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_mopria_shortedge_duplex_portrait
+        +guid:427ac85c-1a67-40aa-b081-f252f68ac0a3
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+    +overrides:
+        +Home:
+            +is_manual:False
+            +timeout:360
+            +test:
+                +dut:
+                    +type:Engine
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_mopria_shortedge_duplex_portrait_file_then_succeeds(self):
+        self.outputsaver.operation_mode('TIFF')
+        job_id = self.print.raw.start('5041d4b1512169d0a43d38657fb4181bdb8e0b49209bcdc194617b65e47bbab8')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_onepage-letter-srgb-8-300dpi.py
+++ b/pwg_new/test_when_printing_pwg_onepage-letter-srgb-8-300dpi.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg onepage letter srgb 8-300dpi page from *onepage-letter-srgb-8-300dpi.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-12138
+    +timeout:300
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:LFP_PrintWorkflows
+    +test_framework:TUF
+    +external_files:onepage-letter-srgb-8-300dpi.pwg=f13e0dac5b5b98707bbca2ec91d6ddb4da6afa114c40f63905d24dfc1cffe07e
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_onepage-letter-srgb-8-300dpi_file_then_succeeds
+    +test:
+        +title:test_pwg_onepage_letter_srgb_8_300dpi
+        +guid:50a1b604-ece6-4040-b0fa-cf5070be5691
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_onepage-letter-srgb-8-300dpi_file_then_succeeds(self):
+        job_id = self.print.raw.start('f13e0dac5b5b98707bbca2ec91d6ddb4da6afa114c40f63905d24dfc1cffe07e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_onepage_letter_srgb_8_300dpi_checksum.py
+++ b/pwg_new/test_when_printing_pwg_onepage_letter_srgb_8_300dpi_checksum.py
@@ -1,0 +1,60 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose: Print job file *onepage-letter-srgb-8-300dpi.pwg
+    +test_tier:1
+    +is_manual:False
+    +reqid:LFPSWQAA-2761
+    +timeout:500
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:LFP_PrintWorkflows
+    +test_framework:TUF
+    +external_files:onepage-letter-srgb-8-300dpi.pwg=f13e0dac5b5b98707bbca2ec91d6ddb4da6afa114c40f63905d24dfc1cffe07e
+    +test_classification:system
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_onepage_letter_srgb_8_300dpi_checksum_file_then_succeeds
+    +test:
+        +title:test_pwg_onepage_letter_srgb_8_300dpi_checksum
+        +guid:81ea9a77-4cab-4ac6-a0ba-3b79d489957d
+        +dut:
+            +type:Simulator, Emulator
+            +configuration:EngineFirmwareFamily=Maia & DocumentFormat=PWGRaster
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_onepage_letter_srgb_8_300dpi_checksum_file_then_succeeds(self):
+        self.outputsaver.operation_mode('CRC')
+        job_id = self.print.raw.start('f13e0dac5b5b98707bbca2ec91d6ddb4da6afa114c40f63905d24dfc1cffe07e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_invalid_bits_per_color_1.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_invalid_bits_per_color_1.py
@@ -1,0 +1,77 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job to verify invalid/negetive test case from *PwgPhOnly-InvalidBitsPerClr-1.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-13665
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-InvalidBitsPerClr-1.pwg=4a65a997ba719712a51a86086b337e66d79224490c0556c1113dac7978ffce96
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_invalid_bits_per_color_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Negative
+    +test:
+        +title:test_pwg_negative_ph_only_invalid_bits_per_color_1
+        +guid:9a2ac8fb-0935-4581-a0c4-8a48e2ca491f
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_invalid_bits_per_color_1_file_then_succeeds(self):
+        job_id = self.print.raw.start('4a65a997ba719712a51a86086b337e66d79224490c0556c1113dac7978ffce96')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_invalid_bits_per_color_2.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_invalid_bits_per_color_2.py
@@ -1,0 +1,67 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job to verify invalid/negetive test case from *PwgPhOnly-InvalidBitsPerClr-2.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-13665
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-InvalidBitsPerClr-2.pwg=87ca72410ac621753b7b42f1c5cecff6f4ba382507dabc954a83b808c45ae476
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_invalid_bits_per_color_2_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Negative
+    +test:
+        +title:test_pwg_negative_ph_only_invalid_bits_per_color_2
+        +guid:fb024ff2-715d-4b6a-9e8f-bea8a4543bb6
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_invalid_bits_per_color_2_file_then_succeeds(self):
+        job_id = self.print.raw.start('87ca72410ac621753b7b42f1c5cecff6f4ba382507dabc954a83b808c45ae476')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_invalid_bits_per_color_3.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_invalid_bits_per_color_3.py
@@ -1,0 +1,67 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job to verify invalid/negetive test case from *PwgPhOnly-InvalidBitsPerClr-3.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-13665
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-InvalidBitsPerClr-3.pwg=6d6803045a3fcb9f80f0e971f0df8924f94e20c6aba39005cf65b6c895c905a0
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_invalid_bits_per_color_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Negative
+    +test:
+        +title:test_pwg_negative_ph_only_invalid_bits_per_color_3
+        +guid:074f4c28-13a7-4dac-9baa-deb312e3cf74
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_invalid_bits_per_color_3_file_then_succeeds(self):
+        job_id = self.print.raw.start('6d6803045a3fcb9f80f0e971f0df8924f94e20c6aba39005cf65b6c895c905a0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_invalid_color_space_1.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_invalid_color_space_1.py
@@ -1,0 +1,67 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job to verify invalid/negetive test case from *PwgPhOnly-InvalidColorspace-1.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-13665
+    +timeout:150
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-InvalidColorspace-1.pwg=295caed41e8e1e7487463c6867a70e3318d29f7f46639decfdb1893e06a18ad7
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_invalid_color_space_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Negative
+    +test:
+        +title:test_pwg_negative_ph_only_invalid_color_space_1
+        +guid:16368ed7-5518-44ab-a0a0-b5f320a4e229
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_invalid_color_space_1_file_then_succeeds(self):
+        job_id = self.print.raw.start('295caed41e8e1e7487463c6867a70e3318d29f7f46639decfdb1893e06a18ad7')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_invalid_color_space_2.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_invalid_color_space_2.py
@@ -1,0 +1,77 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job to verify invalid/negetive test case from *PwgPhOnly-InvalidColorspace-2.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-13665
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-InvalidColorspace-2.pwg=610e0d6981d976d211fe2b49f00e9c6f25ff13d7cdcd8c67315aef6e286e8ea0
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_invalid_color_space_2_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Negative
+    +test:
+        +title:test_pwg_negative_ph_only_invalid_color_space_2
+        +guid:3226574f-fdbd-40bf-8550-590600d6517f
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_invalid_color_space_2_file_then_succeeds(self):
+        job_id = self.print.raw.start('610e0d6981d976d211fe2b49f00e9c6f25ff13d7cdcd8c67315aef6e286e8ea0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_invalid_color_space_3.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_invalid_color_space_3.py
@@ -1,0 +1,67 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job to verify invalid/negetive test case from *PwgPhOnly-InvalidColorspace-3.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-13665
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-InvalidColorspace-3.pwg=f912057b20f81fec781dc3a1432aba08a8b8e8d70d2346298b8aba4b18e75537
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_invalid_color_space_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Negative
+    +test:
+        +title:test_pwg_negative_ph_only_invalid_color_space_3
+        +guid:6b010c36-daa4-469c-bbad-99431bad90dc
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_invalid_color_space_3_file_then_succeeds(self):
+        job_id = self.print.raw.start('f912057b20f81fec781dc3a1432aba08a8b8e8d70d2346298b8aba4b18e75537')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_invalid_num_colors_1.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_invalid_num_colors_1.py
@@ -1,0 +1,67 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job to verify invalid/negetive test case from *PwgPhOnly-InvalidNumColors-1.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-13665
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-InvalidNumColors-1.pwg=9d97e6ca8ea335321c9f62e22aaca43006a2545b6f19a4ad940586d841d4c8d0
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_invalid_num_colors_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Negative
+    +test:
+        +title:test_pwg_negative_ph_only_invalid_num_color_components_per_pixel_1
+        +guid:35de8539-ee33-40d1-90a5-5ac640a90bab
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_invalid_num_colors_1_file_then_succeeds(self):
+        job_id = self.print.raw.start('9d97e6ca8ea335321c9f62e22aaca43006a2545b6f19a4ad940586d841d4c8d0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_invalid_num_colors_2.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_invalid_num_colors_2.py
@@ -1,0 +1,76 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job to verify invalid/negetive test case from *PwgPhOnly-InvalidNumColors-2.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-13665
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-InvalidNumColors-2.pwg=ede85e012b660dc4bf952f03efdd3f0926d2b9f14161e87389b75911b70e926a
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_invalid_num_colors_2_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Negative
+    +test:
+        +title:test_pwg_negative_ph_only_invalid_num_color_components_per_pixel_2
+        +guid:14fc50e6-a727-4753-8ff3-f05d2e782be5
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_invalid_num_colors_2_file_then_succeeds(self):
+        job_id = self.print.raw.start('ede85e012b660dc4bf952f03efdd3f0926d2b9f14161e87389b75911b70e926a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_invalid_num_colors_3.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_invalid_num_colors_3.py
@@ -1,0 +1,67 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job to verify invalid/negetive test case from *PwgPhOnly-InvalidNumColors-3.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-13665
+    +timeout:180
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-InvalidNumColors-3.pwg=fa4c7f9a623ff7e0e6a46cd84e100f83f4a152569a57e5dbb8e97909ac7fda2d
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_invalid_num_colors_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Negative
+    +test:
+        +title:test_pwg_negative_ph_only_invalid_num_color_components_per_pixel_3
+        +guid:489fb2b8-31ac-423d-9282-89d130f8fd70
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_invalid_num_colors_3_file_then_succeeds(self):
+        job_id = self.print.raw.start('fa4c7f9a623ff7e0e6a46cd84e100f83f4a152569a57e5dbb8e97909ac7fda2d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_invalid_res_1.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_invalid_res_1.py
@@ -1,0 +1,67 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:PWG test using **PwgPhOnly-InvalidRes-1.pwg
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-18912
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-InvalidRes-1.pwg=e40cf2498e0c93693c3925a72806922082019946cb59c402cb4a10b305324d5c
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_invalid_res_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Negative
+    +test:
+        +title:test_pwg_negative_ph_only_invalid_resolution_1
+        +guid:d172bd9c-ebab-4f82-acd3-dbdf1a00e72e
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_invalid_res_1_file_then_succeeds(self):
+        job_id = self.print.raw.start('e40cf2498e0c93693c3925a72806922082019946cb59c402cb4a10b305324d5c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_invalid_res_2.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_invalid_res_2.py
@@ -1,0 +1,76 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job to verify invalid/negetive test case from *PwgPhOnly-InvalidRes-2.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-13665
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-InvalidRes-2.pwg=372ca4aaca3caa3825b88a143936fcde0299039b0b115aa6d575e6af703abad0
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_invalid_res_2_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Negative
+    +test:
+        +title:test_pwg_negative_ph_only_invalid_resolution_2
+        +guid:2d5ce266-9c6a-4607-9810-f41cbddc9ddc
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_invalid_res_2_file_then_succeeds(self):
+        job_id = self.print.raw.start('372ca4aaca3caa3825b88a143936fcde0299039b0b115aa6d575e6af703abad0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_invalid_res_3.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_invalid_res_3.py
@@ -1,0 +1,67 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job to verify invalid/negetive test case from *PwgPhOnly-InvalidRes-3.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-13665
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-InvalidRes-3.pwg=3ba04371c66419d45f0c75d8793b6273eb7ca7911cc33cb5d693a929c864992a
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_invalid_res_3_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Negative
+    +test:
+        +title:test_pwg_negative_ph_only_invalid_resolution_3
+        +guid:28dcf01f-66dc-4fa0-9459-951e4aaab453
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_invalid_res_3_file_then_succeeds(self):
+        job_id = self.print.raw.start('3ba04371c66419d45f0c75d8793b6273eb7ca7911cc33cb5d693a929c864992a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_invalid_res_4.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_invalid_res_4.py
@@ -1,0 +1,67 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job to verify invalid/negetive test case from *PwgPhOnly-InvalidRes-4.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-13665
+    +timeout:180
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-InvalidRes-4.pwg=38a6e4e6d09137f2eaa592b5c5b71ba2db4102c67469b2c483f5afe7c45a0fdd
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_invalid_res_4_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Negative
+    +test:
+        +title:test_pwg_negative_ph_only_invalid_resolution_4
+        +guid:2c0e734b-ff8f-483b-b7bd-6101581bb11b
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_invalid_res_4_file_then_succeeds(self):
+        job_id = self.print.raw.start('38a6e4e6d09137f2eaa592b5c5b71ba2db4102c67469b2c483f5afe7c45a0fdd')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pwg_new/test_when_printing_pwg_ph_only_margin_lrtb_1.py
+++ b/pwg_new/test_when_printing_pwg_ph_only_margin_lrtb_1.py
@@ -1,0 +1,76 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    +purpose:Simple print job of pwg ph only margin LRTB-1 page from *PwgPhOnly-MarginLRTB-1.pwg file
+    +test_tier:1
+    +is_manual:False
+    +test_classification:System
+    +reqid:DUNE-13665
+    +timeout:120
+    +asset:PDL_New
+    +delivery_team:QualityGuild
+    +feature_team:PDLSolns
+    +test_framework:TUF
+    +external_files:PwgPhOnly-MarginLRTB-1.pwg=85adf3bb7ab0d844625e6d30efa1a23b624aa796cf17c99301464ea14bf75d70
+    +name:TestWhenPrintingJPEGFile::test_when_using_pwg_ph_only_margin_lrtb_1_file_then_succeeds
+    +categorization:
+        +segment:Platform
+        +area:Print
+        +feature:PDL
+        +sub_feature:PWGRaster
+        +interaction:Headless
+        +test_type:Positive
+    +test:
+        +title:test_pwg_ph_only_margin_lrtb_1_page
+        +guid:aa8892f7-3aae-4d3d-95fe-67711366e9df
+        +dut:
+            +type:Simulator
+            +configuration:DocumentFormat=PWGRaster
+
+    +overrides:
+        +Enterprise:
+            +is_manual:False
+            +timeout:600
+            +test:
+                +dut:
+                    +type:Emulator
+
+
+$$$$$_END_TEST_METADATA_DECLARATION_$$$$"""
+    def test_when_using_pwg_ph_only_margin_lrtb_1_file_then_succeeds(self):
+        job_id = self.print.raw.start('85adf3bb7ab0d844625e6d30efa1a23b624aa796cf17c99301464ea14bf75d70')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+        logging.info("Get crc value for the current print job")
+        Current_crc_value = self.outputsaver.get_crc()
+        logging.info("Validate current crc with master crc")
+        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"


### PR DESCRIPTION
## Summary
- create 30 more refactored PWG tests in `pwg_new`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dunetuf')*

------
https://chatgpt.com/codex/tasks/task_e_6880daa2cb008332a7ba632de842b9ea