### PR TITLE
Add PCL5 new framework tests

### DIFF
--- a/pcl5_new/high-value/test_when_printing_pcl5_highvalue_10page_halflf.py
+++ b/pcl5_new/high-value/test_when_printing_pcl5_highvalue_10page_halflf.py
@@ -71,7 +71,7 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
     def test_when_using_pcl5_highvalue_10page_halflf_file_then_succeeds(self):
-        self.self.outputsaver.validate_crc_tiff()
+        self.outputsaver.validate_crc_tiff()
         if self.get_platform() == 'emulator':
             installed_trays = self.media.tray.get_installed_trays()
             for tray_id in installed_trays:

--- a/pcl5_new/high-value/test_when_printing_pcl5_highvalue_1page_ie_vzw_success_upd_5_7_0_pcl5.py
+++ b/pcl5_new/high-value/test_when_printing_pcl5_highvalue_1page_ie_vzw_success_upd_5_7_0_pcl5.py
@@ -70,7 +70,7 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
     def test_when_using_pcl5_highvalue_1page_ie_vzw_success_upd_5_7_0_pcl5_file_then_succeeds(self):
-        self.self.outputsaver.validate_crc_tiff()
+        self.outputsaver.validate_crc_tiff()
         job_id = self.print.raw.start('2652a046cd23542a8e92bf5b8bab28761e188a5743184d95280c77492e145489')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()

--- a/pcl5_new/high-value/test_when_printing_pcl5_highvalue_2page_mcroexec.py
+++ b/pcl5_new/high-value/test_when_printing_pcl5_highvalue_2page_mcroexec.py
@@ -68,7 +68,7 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
     def test_when_using_pcl5_highvalue_2page_mcroexec_file_then_succeeds(self):
-        self.self.outputsaver.validate_crc_tiff()
+        self.outputsaver.validate_crc_tiff()
         job_id = self.print.raw.start('88771a72bf97e33f909901abb64a258bc4c159a19a4f73cf2fdd3847ea123c75')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()

--- a/pcl5_new/low-value/test_when_printing_pcl5_lowvaluenew_16page_ttulineb.py
+++ b/pcl5_new/low-value/test_when_printing_pcl5_lowvaluenew_16page_ttulineb.py
@@ -69,7 +69,7 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
     def test_when_using_pcl5_lowvaluenew_16page_ttulineb_file_then_succeeds(self):
-        self.self.outputsaver.validate_crc_tiff()
+        self.outputsaver.validate_crc_tiff()
         job_id = self.print.raw.start('449f26e9217efb5a25d8052b308d8d14d910ff4b104251b04ce1ecff539bd97e')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()

--- a/pcl5_new/low-value/test_when_printing_pcl5_lowvaluenew_48page_rgb.py
+++ b/pcl5_new/low-value/test_when_printing_pcl5_lowvaluenew_48page_rgb.py
@@ -69,7 +69,7 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
     def test_when_using_pcl5_lowvaluenew_48page_rgb_file_then_succeeds(self):
-        self.self.outputsaver.validate_crc_tiff()
+        self.outputsaver.validate_crc_tiff()
         job_id = self.print.raw.start('0c1b2d6554edf75fd2eb788a00fc4b0dae03a8679cc0e5ba2c72892e7fb81b46')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()

--- a/pcl5_new/test_when_printing__pcl5_inherit_media_type.py
+++ b/pcl5_new/test_when_printing__pcl5_inherit_media_type.py
@@ -2,6 +2,8 @@ import logging
 from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from dunetuf.print.output.intents import Intents, MediaSize, MediaType, MediaSource
+
 
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
@@ -30,19 +32,19 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
+        +purpose:test for pcl5 for inherit media type from tray functionality
         +test_tier: 1
         +is_manual: False
         +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +reqid: DUNE-13650
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
         +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
+        +external_files:tray1_a4_notype_pcl5.prn=5ac9906a9fe61f103123109d5b147e5618a7cfd9f7faee8d4a8918849ab98a28
         +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +name:TestWhenPrintingJPEGFile::test_when_using__pcl5_inherit_media_type_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +53,24 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title: test_pcl5_inherit_media_type
+            +guid:e14e4bfd-e3ed-4ab4-a3cb-6c978dc6de3d
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration: DocumentFormat=PCL5 & MediaType=Bond & MediaInputInstalled=Tray1 & MediaSizeSupported=iso_a4_210x297mm
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using__pcl5_inherit_media_type_file_then_succeeds(self):
+        if self.media.is_size_supported('iso_a4_210x297mm', 'tray-1') and tray.is_type_supported('stationery-bond', 'tray-1'):
+            self.media.tray.configure_tray('tray-1', 'iso_a4_210x297mm', 'stationery-bond')
+
+        job_id = self.print.raw.start('5ac9906a9fe61f103123109d5b147e5618a7cfd9f7faee8d4a8918849ab98a28')
         self.print.wait_for_job_completion(job_id)
+        outputverifier.save_and_parse_output()
+        outputverifier.verify_media_size(Intents.printintent, MediaSize.a4)
+        outputverifier.verify_media_type(Intents.printintent, MediaType.bond)
+        outputverifier.verify_media_source(Intents.printintent, MediaSource.tray1)
+
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+        self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pcl5_10pages_mono.py
+++ b/pcl5_new/test_when_printing_pcl5_10pages_mono.py
@@ -1,0 +1,83 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from dunetuf.print.output.intents import Intents, MediaType, MediaSize, ColorMode
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Simple print job of Pcl5 letter Page from 10pgs_Letter_Plain.prn file
+        +test_tier:1
+        +is_manual:False
+        +test_classification:System
+        +reqid:DUNE-223392
+        +timeout:180
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework:TUF
+        +external_files:10pgs_Letter_Plain.prn=81b00eaa2f06be2bdf7b27f025c6b703da3c600b4fdb28a06086f0bb4236af47
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_10pages_mono_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title:test_pcl5_10pages_mono
+            +guid:447b72e9-d0d2-4fb4-86c6-57a69e8dec14
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_10pages_mono_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+
+        default = self.media.get_default_source()
+        if tray.is_media_combination_supported(default, 'na_letter_8.5x11in', 'stationery'):
+             self.media.tray.configure_tray(default, 'na_letter_8.5x11in', 'stationery')
+             job_id = self.print.raw.start('81b00eaa2f06be2bdf7b27f025c6b703da3c600b4fdb28a06086f0bb4236af47')
+             self.print.wait_for_job_completion(job_id)
+
+             outputverifier.save_and_parse_output()
+             outputverifier.verify_media_size(Intents.printintent, MediaSize.letter)
+             outputverifier.verify_media_type(Intents.printintent, MediaType.stationery)
+             outputverifier.verify_color_mode(Intents.printintent, ColorMode.monochrome)
+             self.outputsaver.operation_mode('NONE')
+
+             Current_crc_value = self.outputsaver.get_crc()
+             assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+        else:
+            logging.info('Media size na_letter_8.5x11in is not supported in the default tray')    
+
+        self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pcl5_1page_FontDBform.py
+++ b/pcl5_new/test_when_printing_pcl5_1page_FontDBform.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,19 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
+        +purpose: unitoffice.prn is a customer escalation file where some text are bold font  and other are printing in regular font
         +test_tier: 1
         +is_manual: False
         +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +reqid: DUNE-211735
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
         +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
+        +external_files:unit1office.prn=a6cdcd7b0413452bb3ddb814008c26c845a8dce630a23fc9c411ee091add7beb
         +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_1page_FontDBform_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,27 +52,22 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title: test_pcl5_1page_FontDBform
+            +guid:81ff8aa9-dfac-4b9a-b567-aff529fbb22e
             +dut:
                 +type:Simulator
                 +configuration: DocumentFormat=PCL5
 
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
-
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
+    def test_when_using_pcl5_1page_FontDBform_file_then_succeeds(self):
         self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+        default = self.media.get_default_source()
+        if self.media.is_size_supported('iso_ra4_215x305mm', default):
+            self.media.tray.configure_tray(default, 'iso_ra4_215x305mm', 'stationery')
+        job_id = self.print.raw.start('a6cdcd7b0413452bb3ddb814008c26c845a8dce630a23fc9c411ee091add7beb')
         self.print.wait_for_job_completion(job_id)
+        outputverifier.save_and_parse_output()
         self.outputsaver.save_output()
         self.outputsaver.operation_mode('NONE')
         logging.info("Get crc value for the current print job")

--- a/pcl5_new/test_when_printing_pcl5_1page_job_with_pdl_configurations.py
+++ b/pcl5_new/test_when_printing_pcl5_1page_job_with_pdl_configurations.py
@@ -2,6 +2,8 @@ import logging
 from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
 
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
@@ -30,19 +32,19 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
+        +purpose: pcl5 job using pdl configurations from job overidding front panel
         +test_tier: 1
         +is_manual: False
         +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +reqid: DUNE-94044
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
         +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
+        +external_files:test_pcl5_withPdlConfigurations.prn=edea21fe4183c8973e6d679560175ce675ab259cd7a93810fec0736e3d704293
         +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_1page_job_with_pdl_configurations_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,8 +53,8 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title: test_pcl5_1page_job_with_pdl_configurations
+            +guid:16ee2ea1-888d-47fe-a9fd-13902d7bb921
             +dut:
                 +type:Simulator
                 +configuration: DocumentFormat=PCL5
@@ -68,12 +70,14 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
+    def test_when_using_pcl5_1page_job_with_pdl_configurations_file_then_succeeds(self):
         self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+        job_id = self.print.raw.start('edea21fe4183c8973e6d679560175ce675ab259cd7a93810fec0736e3d704293')
         self.print.wait_for_job_completion(job_id)
+        outputverifier.save_and_parse_output()
         self.outputsaver.save_output()
         self.outputsaver.operation_mode('NONE')
+
         logging.info("Get crc value for the current print job")
         Current_crc_value = self.outputsaver.get_crc()
         logging.info("Validate current crc with master crc")

--- a/pcl5_new/test_when_printing_pcl5_1page_job_without_pdl_configurations.py
+++ b/pcl5_new/test_when_printing_pcl5_1page_job_without_pdl_configurations.py
@@ -2,6 +2,8 @@ import logging
 from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
 
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
@@ -30,19 +32,19 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
+        +purpose: pcl5 job using default pdl configurations from front panel
         +test_tier: 1
         +is_manual: False
         +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +reqid: DUNE-94044
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
         +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
+        +external_files:test_pcl5_withoutPdlConfigurations.prn=9bb630ac7c088eb5ea4d99a98e021f3419386831cd5db73991e3bf321a69953a
         +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_1page_job_without_pdl_configurations_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,8 +53,8 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title: test_pcl5_1page_job_without_pdl_configurations
+            +guid:27106345-f68a-461a-b4a5-f8e4d103f5f0
             +dut:
                 +type:Simulator
                 +configuration: DocumentFormat=PCL5
@@ -68,12 +70,14 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
+    def test_when_using_pcl5_1page_job_without_pdl_configurations_file_then_succeeds(self):
         self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+        job_id = self.print.raw.start('9bb630ac7c088eb5ea4d99a98e021f3419386831cd5db73991e3bf321a69953a')
         self.print.wait_for_job_completion(job_id)
+        outputverifier.save_and_parse_output()
         self.outputsaver.save_output()
         self.outputsaver.operation_mode('NONE')
+
         logging.info("Get crc value for the current print job")
         Current_crc_value = self.outputsaver.get_crc()
         logging.info("Validate current crc with master crc")

--- a/pcl5_new/test_when_printing_pcl5_1page_landscape_job.py
+++ b/pcl5_new/test_when_printing_pcl5_1page_landscape_job.py
@@ -2,6 +2,8 @@ import logging
 from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
 
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
@@ -30,51 +32,29 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
+        +purpose: pcl5 job with landscape orientation in late rotation support product
+        +test_tier: 3
         +is_manual: False
         +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +reqid: DUNE-188868
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
-        +feature_team:PDLSolns
+        +feature_team:ENTA4ProductTest
         +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
+        +external_files:test_pcl5_orientation_landscape.prn=ecca56a0ced0e36a48c8498f152a1db77f3c3cfc84e47531c731637c39fa943c
         +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
-        +categorization:
-            +segment:Platform
-            +area:Print
-            +feature:PDL
-            +sub_feature:PCL5
-            +interaction:Headless
-            +test_type:Positive
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_1page_landscape_job_file_then_succeeds
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title: test_pcl5_1page_landscape_job
+            +guid:22ac3b86-0566-4387-b887-51055e729c21
             +dut:
                 +type:Simulator
                 +configuration: DocumentFormat=PCL5
 
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
-
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_1page_landscape_job_file_then_succeeds(self):
+        job_id = self.print.raw.start('ecca56a0ced0e36a48c8498f152a1db77f3c3cfc84e47531c731637c39fa943c')
         self.print.wait_for_job_completion(job_id)
-        self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+        outputverifier.verify_content_orientation(Intents.printintent, ContentOrientation.landscape)

--- a/pcl5_new/test_when_printing_pcl5_2pgs_Letter_Plain_Landscape_job.py
+++ b/pcl5_new/test_when_printing_pcl5_2pgs_Letter_Plain_Landscape_job.py
@@ -2,6 +2,8 @@ import logging
 from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
 
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
@@ -30,19 +32,19 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
+        +purpose: pcl5 job with landscape orientation in late rotation support product
         +test_tier: 1
         +is_manual: False
         +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +reqid: DUNE-196321
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
         +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
+        +external_files:2pgs_Letter_Plain_PUNCH_LEFT_2PT_US_engT1_exB1_for_PAPERSIZEPROBLEM.prn=bbfb00aac7de4e314baf9dc162a1f771fe519d3c513686a27c6bca03d15463d9
         +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_2pgs_Letter_Plain_Landscape_job_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +53,24 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title: test_pcl5_2pgs_Letter_Plain_Landscape_job
+            +guid:a1697d6c-801d-4be7-b4d4-f8c714787b4c
             +dut:
                 +type:Simulator
                 +configuration: DocumentFormat=PCL5
 
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
-
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
+    def test_when_using_pcl5_2pgs_Letter_Plain_Landscape_job_file_then_succeeds(self):
         self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+        job_id = self.print.raw.start('bbfb00aac7de4e314baf9dc162a1f771fe519d3c513686a27c6bca03d15463d9')
         self.print.wait_for_job_completion(job_id)
+        outputverifier.save_and_parse_output()
         self.outputsaver.save_output()
         self.outputsaver.operation_mode('NONE')
         logging.info("Get crc value for the current print job")
         Current_crc_value = self.outputsaver.get_crc()
         logging.info("Validate current crc with master crc")
         assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+        outputverifier.verify_content_orientation(Intents.printintent, ContentOrientation.landscape)
+

--- a/pcl5_new/test_when_printing_pcl5_39683_hva020_49_alm_prn.py
+++ b/pcl5_new/test_when_printing_pcl5_39683_hva020_49_alm_prn.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:39683-HVA020_49_ALM.prn=5446f465ef0e7c9d4fccc3207a7c0851ed5e11810eb716dc0f5ceeee117a2a50
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_39683_hva020_49_alm_prn_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,15 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_39683_hva020_49_alm_prn
+            +guid:5fcdb518-b548-4d83-9197-3a415f2bbc8a
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_39683_hva020_49_alm_prn_file_then_succeeds(self):
+        job_id = self.print.raw.start('5446f465ef0e7c9d4fccc3207a7c0851ed5e11810eb716dc0f5ceeee117a2a50')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_JapaneseNewEraFont.py
+++ b/pcl5_new/test_when_printing_pcl5_JapaneseNewEraFont.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,51 +31,30 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
+        +purpose: Test Japanese New Era Font in PCL5
+        +test_tier:3
         +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +reqid: DUNE-107248
+        +timeout: 600
         +asset:PDL_New
         +delivery_team:QualityGuild
-        +feature_team:PDLSolns
+        +feature_team:ENTA4ProductTest
         +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
-        +categorization:
-            +segment:Platform
-            +area:Print
-            +feature:PDL
-            +sub_feature:PCL5
-            +interaction:Headless
-            +test_type:Positive
+        +external_files: JapaneseNewEra_PCL_Test.prn=3739e2db13da0d4d81d504e60001efec297331e8adf8c0d74817477e7b837acf
+        +test_classification: System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_JapaneseNewEraFont_file_then_succeeds
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_JapaneseNewEraFont
+            +guid:62e02baf-b25f-4f73-9328-61358dd1a087
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5 
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
+    def test_when_using_pcl5_JapaneseNewEraFont_file_then_succeeds(self):
         self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
-        self.print.wait_for_job_completion(job_id)
+        self.print.raw.start("3739e2db13da0d4d81d504e60001efec297331e8adf8c0d74817477e7b837acf")
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
         Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
         assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_UseAfterFree.py
+++ b/pcl5_new/test_when_printing_pcl5_UseAfterFree.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 security vulnerability
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:pclpat.prn=9cfed0952cb371c6de7fc8a576d5f6c20899e48b13ba9ab235123916f21a54a7
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_UseAfterFree_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,15 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_UseAfterFree
+            +guid:a777b810-0711-422c-a527-4c0e8eb9b9af
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_UseAfterFree_file_then_succeeds(self):
+        job_id = self.print.raw.start('9cfed0952cb371c6de7fc8a576d5f6c20899e48b13ba9ab235123916f21a54a7')
         self.print.wait_for_job_completion(job_id)
-        self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+        self.outputsaver.save_output() 

--- a/pcl5_new/test_when_printing_pcl5_a3.py
+++ b/pcl5_new/test_when_printing_pcl5_a3.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:a3.pcl=e2a95201a4d9f98aec6bff6e71e7422153a31dda8659c4f066858a98c9106b36
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_a3_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,23 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_a3
+            +guid:b0deb7c1-0c94-4a62-a0bc-fec8861031f1
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
+                +configuration:DocumentFormat=PCL5
         +overrides:
-            +Enterprise:
+            +Home:
                 +is_manual:False
-                +timeout:600
+                +timeout:240
                 +test:
                     +dut:
-                        +type:Emulator
-
-
+                        +type:Engine
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
+    def test_when_using_pcl5_a3_file_then_succeeds(self):
         self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+        job_id = self.print.raw.start('e2a95201a4d9f98aec6bff6e71e7422153a31dda8659c4f066858a98c9106b36')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+

--- a/pcl5_new/test_when_printing_pcl5_a5.py
+++ b/pcl5_new/test_when_printing_pcl5_a5.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464	
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:a5.pcl=831bfada72d92e0f3ab8cb9fac5f090773490f35bbb1045b026811f4b1cc3a96
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_a5_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,17 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_a5
+            +guid:16636ac2-fdad-49c1-b785-09c58b7066e4
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_a5_file_then_succeeds(self):
+        if self.media.is_size_supported('iso_a5_148x210mm','tray-1'):
+            self.media.tray.configure_tray('tray-1', 'iso_a5_148x210mm', 'any')
+        job_id = self.print.raw.start('831bfada72d92e0f3ab8cb9fac5f090773490f35bbb1045b026811f4b1cc3a96')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_a6.py
+++ b/pcl5_new/test_when_printing_pcl5_a6.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464	
+        +timeout:240
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:a6.pcl=dc0d40eb3bce9b392efecd10234a0fb2ef0449e879cf5e918abff5cb3fb617c5
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_a6_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,23 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_a6
+            +guid:885e28c5-9afd-4f8e-90ac-c0c451305e45
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
+                +configuration:DocumentFormat=PCL5
         +overrides:
-            +Enterprise:
+            +Home:
                 +is_manual:False
-                +timeout:600
+                +timeout:240
                 +test:
                     +dut:
-                        +type:Emulator
-
-
+                        +type:Engine
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_a6_file_then_succeeds(self):
+        if self.media.is_size_supported('iso_a6_105x148mm','tray-1'):
+            self.media.tray.configure_tray('tray-1', 'iso_a6_105x148mm', 'any')
+        job_id = self.print.raw.start('dc0d40eb3bce9b392efecd10234a0fb2ef0449e879cf5e918abff5cb3fb617c5')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_ac6zqhdm_netconx_pcl_0600_9500_prn.py
+++ b/pcl5_new/test_when_printing_pcl5_ac6zqhdm_netconx_pcl_0600_9500_prn.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464	
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:AC6ZQHDM_Netconx.pcl.0600.9500.prn=f266c7af1c5ef346dcdfdab354aae6702b72fdd684e71ec41c697a09f62a905f
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_ac6zqhdm_netconx_pcl_0600_9500_prn_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,15 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_ac6zqhdm_netconx_pcl_0600_9500_prn
+            +guid:63af21e2-bec3-4e7f-a2a8-f404af1a400f
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_ac6zqhdm_netconx_pcl_0600_9500_prn_file_then_succeeds(self):
+        job_id = self.print.raw.start('f266c7af1c5ef346dcdfdab354aae6702b72fdd684e71ec41c697a09f62a905f')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_b4.py
+++ b/pcl5_new/test_when_printing_pcl5_b4.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:b4.pcl=d1dd3f083ba21baddfd979700b56e3a3f9eab67d1c9d4fa1385cdf445c080116
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_b4_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,15 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_b4
+            +guid:01d902ba-7489-4cdc-ab97-1b741d960b16
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_b4_file_then_succeeds(self):
+        job_id = self.print.raw.start('d1dd3f083ba21baddfd979700b56e3a3f9eab67d1c9d4fa1385cdf445c080116')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_b410.py
+++ b/pcl5_new/test_when_printing_pcl5_b410.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464	
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:b410.pcl=4b15dc315247658a8bc18be459bd93afbf19e3d106a67d5eb5d1fc98ba7facf5
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_b410_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,17 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_b410
+            +guid:6d452037-d7b0-4b49-a8a8-e4aae42b075a
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_b410_file_then_succeeds(self):
+        if self.media.is_size_supported('jis_b5_182x257mm','tray-1'):
+            self.media.tray.configure_tray('tray-1', 'jis_b5_182x257mm', 'any')
+        job_id = self.print.raw.start('4b15dc315247658a8bc18be459bd93afbf19e3d106a67d5eb5d1fc98ba7facf5')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_b5env.py
+++ b/pcl5_new/test_when_printing_pcl5_b5env.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:b5env.pcl=0c2896b056a5d8470f43109ac1333e3dcc225a64d2538554c8cd68ac15b2ce6e
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_b5env_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,17 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_b5env
+            +guid:c07b729e-5a87-43b4-a5de-2c943e4afd60
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_b5env_file_then_succeeds(self):
+        if self.media.is_size_supported('iso_b5_176x250mm','tray-1'):
+            self.media.tray.configure_tray('tray-1', 'iso_b5_176x250mm', 'any')
+        job_id = self.print.raw.start('0c2896b056a5d8470f43109ac1333e3dcc225a64d2538554c8cd68ac15b2ce6e')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_b6.py
+++ b/pcl5_new/test_when_printing_pcl5_b6.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:b6.pcl=650c187424b33c3636b91877f09d20f158e5d9d307a37161af192d199bc4d790
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_b6_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,15 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_b6
+            +guid:68ac631b-00be-4051-9b0e-959e8477d13f
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_b6_file_then_succeeds(self):
+        job_id = self.print.raw.start('650c187424b33c3636b91877f09d20f158e5d9d307a37161af192d199bc4d790')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_c5.py
+++ b/pcl5_new/test_when_printing_pcl5_c5.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:c5.pcl=d2c065f69e2b35312fefd6dc81626940cab1f72820034b9468a6adfaebe477c2
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_c5_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,17 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_c5
+            +guid:4e653f3a-2ef2-431f-9113-b3f1e5ec9fba
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_c5_file_then_succeeds(self):
+        if self.media.is_size_supported('iso_c5_162x229mm','tray-1'):
+            self.media.tray.configure_tray('tray-1', 'iso_c5_162x229mm', 'any')
+        job_id = self.print.raw.start('d2c065f69e2b35312fefd6dc81626940cab1f72820034b9468a6adfaebe477c2')
         self.print.wait_for_job_completion(job_id)
-        self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+        self.outputsaver.save_output()  

--- a/pcl5_new/test_when_printing_pcl5_com10.py
+++ b/pcl5_new/test_when_printing_pcl5_com10.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:com10.pcl=66ab177d91aa66c5ca406812fe4e8d68ed66a73b2b1fa171b4b1b3fa01d84612
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_com10_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,17 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_com10
+            +guid:5a2d78c7-076d-46bb-b39f-e7e6c4afaf63
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_com10_file_then_succeeds(self):
+        if self.media.is_size_supported('na_number-10_4.125x9.5in','tray-1'):
+            self.media.tray.configure_tray('tray-1', 'na_number-10_4.125x9.5in', 'any')
+        job_id = self.print.raw.start('66ab177d91aa66c5ca406812fe4e8d68ed66a73b2b1fa171b4b1b3fa01d84612')
         self.print.wait_for_job_completion(job_id)
-        self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+        self.outputsaver.save_output() 

--- a/pcl5_new/test_when_printing_pcl5_dl.py
+++ b/pcl5_new/test_when_printing_pcl5_dl.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:dl.pcl=ebe1f946cda65072265ab698b1be1f0c4c220925a30a52be45d96cd60963e3ed
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_dl_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,17 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_dl
+            +guid:99b5d8bd-f220-4d5a-aa82-f86fc6a0dd05
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_dl_file_then_succeeds(self):
+        if self.media.is_size_supported('iso_dl_110x220mm','tray-1'):
+            self.media.tray.configure_tray('tray-1', 'iso_dl_110x220mm', 'any')
+        job_id = self.print.raw.start('ebe1f946cda65072265ab698b1be1f0c4c220925a30a52be45d96cd60963e3ed')
         self.print.wait_for_job_completion(job_id)
-        self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+        self.outputsaver.save_output() 

--- a/pcl5_new/test_when_printing_pcl5_executive.py
+++ b/pcl5_new/test_when_printing_pcl5_executive.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:executive.pcl=8c506918be57ab4d038b3cf3429f6b5fd64c3a0edba8f0f206455cc0e7ec8db0
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_executive_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,17 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_executive
+            +guid:7ffa630b-c3a5-416e-9dc4-9fae36e088d2
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_executive_file_then_succeeds(self):
+        if self.media.is_size_supported('na_executive_7.25x10.5in','tray-1'):
+            self.media.tray.configure_tray('tray-1', 'na_executive_7.25x10.5in', 'any')
+        job_id = self.print.raw.start('8c506918be57ab4d038b3cf3429f6b5fd64c3a0edba8f0f206455cc0e7ec8db0')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_font_download_command.py
+++ b/pcl5_new/test_when_printing_pcl5_font_download_command.py
@@ -2,6 +2,8 @@ import logging
 from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
 
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
@@ -30,19 +32,19 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
+        +purpose: pcl5 job with Font download command support 
         +test_tier: 1
         +is_manual: False
         +test_classification: 1
-        +reqid: DUNE-37356
+        +reqid: DUNE-191473
         +timeout:600
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
         +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
+        +external_files: targetfiles_maser_test.sentry.pcl=7ddc731ae41dde0fd48341f224d1010f4fd20423512d4d250381629734a5b9ca
         +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_font_download_command_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +53,14 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title: test_pcl5_font_download_command
+            +guid:380b1d15-91d0-4ba4-bcfe-eed6627ac56c
             +dut:
-                +type:Simulator
+                +type: Simulator
                 +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_font_download_command_file_then_succeeds(self):
+        job_id = self.print.raw.start('7ddc731ae41dde0fd48341f224d1010f4fd20423512d4d250381629734a5b9ca')
         self.print.wait_for_job_completion(job_id)
-        self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_helv_prn.py
+++ b/pcl5_new/test_when_printing_pcl5_helv_prn.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:400
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:helv.prn=aab726f824d40df2a9bf1d962e8021c147bf41df4ea5d89175532379f911ee98
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_helv_prn_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,15 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_helv_prn
+            +guid:decd082c-ba73-4745-9e72-49e73aa37b5d
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_helv_prn_file_then_succeeds(self):
+        job_id = self.print.raw.start('aab726f824d40df2a9bf1d962e8021c147bf41df4ea5d89175532379f911ee98')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_job_cancel.py
+++ b/pcl5_new/test_when_printing_pcl5_job_cancel.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Testing cancel of pcl5 jobs 
+        +test_tier:1
+        +is_manual:False
+        +reqid:DUNE-236978
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
+        +test_framework:TUF
+        +external_files:66Page-pixel.obj=36342bd755c3212a1782f3f9a1afc6b11910e9dfed1102b4815d01ad532b2bd3
         +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_job_cancel_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,22 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title: test_pcl5_job_cancel
+            +guid:73f4ffa7-d248-428b-90b9-52acea34f61e
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration: DocumentFormat=PCL5   
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_job_cancel_file_then_succeeds(self):
+        logging.debug("Perform print job")
+        job_id = self.print.raw.start('36342bd755c3212a1782f3f9a1afc6b11910e9dfed1102b4815d01ad532b2bd3')
         self.print.wait_for_job_completion(job_id)
-        self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+
+        logging.info('Canceling print job')
+        printjob.job.cancel_active_jobs()
+
+        logging.info('Waiting for job cancellation')
+        jobstate = self.print.wait_for_job_completion(jobid,120)
+        assert 'CANCELED' in jobstate, "Unexpected final job state - {0}".format(jobstate)

--- a/pcl5_new/test_when_printing_pcl5_jpostd.py
+++ b/pcl5_new/test_when_printing_pcl5_jpostd.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:jpostd.pcl=f185748f0a52dc14d07175ff17cfdc199d6ff9ea677dc434adbcb107186aa216
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_jpostd_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,15 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_jpostd
+            +guid:3ddd8c74-7d22-46d6-9fd0-a101e8ff5bf8
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_jpostd_file_then_succeeds(self):
+        job_id = self.print.raw.start('f185748f0a52dc14d07175ff17cfdc199d6ff9ea677dc434adbcb107186aa216')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_mediadest0_5.py
+++ b/pcl5_new/test_when_printing_pcl5_mediadest0_5.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:500
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:MediaDest0-5.pcl=0e794dccb160967c819cd4a48c35c9f916dad145ef3af8a0ef7816cfe60e5b58
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_mediadest0_5_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,15 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_mediadest0_5
+            +guid:61821742-1336-4c35-9078-741e53e758ca
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_mediadest0_5_file_then_succeeds(self):
+        job_id = self.print.raw.start('0e794dccb160967c819cd4a48c35c9f916dad145ef3af8a0ef7816cfe60e5b58')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_monarch.py
+++ b/pcl5_new/test_when_printing_pcl5_monarch.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:monarch.pcl=02c197a1c0beb8fa2ede54d3675a3476634434b377bfdff5a3979e76194bd057
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_monarch_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,17 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_monarch
+            +guid:045977a2-6735-40cf-af9f-a3da6f1a84a7
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_monarch_file_then_succeeds(self):
+        if self.media.is_size_supported('na_monarch_3.875x7.5in','tray-1'):
+            self.media.tray.configure_tray('tray-1', 'na_monarch_3.875x7.5in', 'any')
+        job_id = self.print.raw.start('02c197a1c0beb8fa2ede54d3675a3476634434b377bfdff5a3979e76194bd057')
         self.print.wait_for_job_completion(job_id)
-        self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+        self.outputsaver.save_output() 

--- a/pcl5_new/test_when_printing_pcl5_officio_prn.py
+++ b/pcl5_new/test_when_printing_pcl5_officio_prn.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:500
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:officio.prn=9fa4f8ad2821d45fa54ca21eb3f94fc75ac56e58d39ebf2ba6127a72bd3723e5
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_officio_prn_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,17 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_officio_prn
+            +guid:912d49a9-3bd5-4735-9f89-f7dc7a48b167
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_officio_prn_file_then_succeeds(self):
+        if self.media.is_size_supported('na_foolscap_8.5x13in','tray-1'):
+            self.media.tray.configure_tray('tray-1', 'na_foolscap_8.5x13in', 'any')
+        job_id = self.print.raw.start('9fa4f8ad2821d45fa54ca21eb3f94fc75ac56e58d39ebf2ba6127a72bd3723e5')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_r600_pcl_hagaki_postcard_simplex_34494_hagaki_pcl5_5_0_3_prn.py
+++ b/pcl5_new/test_when_printing_pcl5_r600_pcl_hagaki_postcard_simplex_34494_hagaki_pcl5_5_0_3_prn.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:R600_pcl_Hagaki_Postcard_Simplex_34494-hagaki_PCL5-5.0.3.prn=86caa399c49d18f7711d719d69a045a1e0eabed957e7d9a1ee60c11ddb9189cd
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_r600_pcl_hagaki_postcard_simplex_34494_hagaki_pcl5_5_0_3_prn_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,17 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_r600_pcl_hagaki_postcard_simplex_34494_hagaki_pcl5_5_0_3_prn
+            +guid:bf45c500-92b9-4e9f-ba3e-f7228305a4ed
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_r600_pcl_hagaki_postcard_simplex_34494_hagaki_pcl5_5_0_3_prn_file_then_succeeds(self):
+        if self.media.is_size_supported('jpn_hagaki_100x148mm','tray-1'):
+            self.media.tray.configure_tray('tray-1', 'jpn_hagaki_100x148mm', 'any')
+        job_id = self.print.raw.start('86caa399c49d18f7711d719d69a045a1e0eabed957e7d9a1ee60c11ddb9189cd')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pcl5_r600_pcl_letter_simplex_43761_manualfeed_a_prn.py
+++ b/pcl5_new/test_when_printing_pcl5_r600_pcl_letter_simplex_43761_manualfeed_a_prn.py
@@ -2,6 +2,8 @@ import logging
 from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from time import sleep
+
 
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
@@ -30,19 +32,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:240
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:R600_pcl_letter_Simplex_43761-Manualfeed_a.prn=1969fa9cbf3b1882b73456c9d013270c534d1938f9ff072268716f8d0499d4cf
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_r600_pcl_letter_simplex_43761_manualfeed_a_prn_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +52,21 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_r600_pcl_letter_simplex_43761_manualfeed_a_prn
+            +guid:01ecdde0-0438-4bcc-b6f2-6482ddbfebe0
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
-
+                +configuration:DocumentFormat=PCL5 & MediaInputInstalled=ManualFeed
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
-        self.print.wait_for_job_completion(job_id)
+    def test_when_using_pcl5_r600_pcl_letter_simplex_43761_manualfeed_a_prn_file_then_succeeds(self):
+        default = self.media.get_default_source()
+        jobid = self.print.raw.start("1969fa9cbf3b1882b73456c9d013270c534d1938f9ff072268716f8d0499d4cf")
+
+        media.wait_for_alerts('mediaManualLoadFlow')
+        self.media.tray.configure_tray(default, 'na_letter_8.5x11in', 'stationery')
+        tray.load_media(default)
+        sleep(5)
+        printjob.wait_verify_job_completion(jobid)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+        self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pcl5_r600_pcl_letter_simplex_43761_manualfeed_b_prn.py
+++ b/pcl5_new/test_when_printing_pcl5_r600_pcl_letter_simplex_43761_manualfeed_b_prn.py
@@ -2,6 +2,8 @@ import logging
 from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from time import sleep
+
 
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
@@ -30,19 +32,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:240
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:R600_pcl_letter_Simplex_43761-Manualfeed_b.prn=d531678fb2fa78b475719b83003f2ff2930a64b248518412cfd7907f00957d89
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_r600_pcl_letter_simplex_43761_manualfeed_b_prn_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +52,21 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_r600_pcl_letter_simplex_43761_manualfeed_b_prn
+            +guid:a9997c9d-f781-48ec-994f-7356acb81ca7
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
-
+                +configuration:DocumentFormat=PCL5 & MediaInputInstalled=ManualFeed
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
-        self.print.wait_for_job_completion(job_id)
+    def test_when_using_pcl5_r600_pcl_letter_simplex_43761_manualfeed_b_prn_file_then_succeeds(self):
+        default = self.media.get_default_source()
+        jobid = self.print.raw.start("d531678fb2fa78b475719b83003f2ff2930a64b248518412cfd7907f00957d89")
+
+        media.wait_for_alerts('mediaManualLoadFlow')
+        self.media.tray.configure_tray(default, 'na_letter_8.5x11in', 'stationery')
+        tray.load_media(default)
+        sleep(5)
+        printjob.wait_verify_job_completion(jobid)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+        self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pcl5_r600_pcl_simplex_letter_43761_1tray1_simplex_prn.py
+++ b/pcl5_new/test_when_printing_pcl5_r600_pcl_simplex_letter_43761_1tray1_simplex_prn.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:R600_pcl_Simplex_letter_43761-1Tray1_Simplex.prn=cea8434052273b26c90bf45289f9f7d2410136b02a8e7eb28dd4776ea60e9f40
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_r600_pcl_simplex_letter_43761_1tray1_simplex_prn_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,15 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_r600_pcl_simplex_letter_43761_1tray1_simplex_prn
+            +guid:55746db4-058e-4597-9ee5-1a7bd9d23a41
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_r600_pcl_simplex_letter_43761_1tray1_simplex_prn_file_then_succeeds(self):
+        job_id = self.print.raw.start('cea8434052273b26c90bf45289f9f7d2410136b02a8e7eb28dd4776ea60e9f40')
         self.print.wait_for_job_completion(job_id)
-        self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+        self.outputsaver.save_output()                

--- a/pcl5_new/test_when_printing_pcl5_splr.py
+++ b/pcl5_new/test_when_printing_pcl5_splr.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:splr.pcl=0de90cd6ad7c1995326cd790cb8ccc0e7445e736fe3564d04d10585f9f853ac8
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_splr_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,15 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_splr
+            +guid:c5dfc20d-c7e8-4c8c-8d83-45c546373cac
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
+                +configuration:DocumentFormat=PCL5
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_splr_file_then_succeeds(self):
+        job_id = self.print.raw.start('0de90cd6ad7c1995326cd790cb8ccc0e7445e736fe3564d04d10585f9f853ac8')
         self.print.wait_for_job_completion(job_id)
-        self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+        self.outputsaver.save_output() 

--- a/pcl5_new/test_when_printing_pcl5_targetfiles_maser_test_pw9p2hdm_sentry_pcl_0600_4500_mas_prn.py
+++ b/pcl5_new/test_when_printing_pcl5_targetfiles_maser_test_pw9p2hdm_sentry_pcl_0600_4500_mas_prn.py
@@ -3,6 +3,7 @@ from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
 
+
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
     def setup_class(cls):
@@ -30,19 +31,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
-        +test_tier: 1
-        +is_manual: False
-        +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +purpose:Adding new system tests for PCL5 missing coverage
+        +test_tier:1
+        +is_manual:False
+        +test_classification:1
+        +reqid:DUNE-197464
+        +timeout:240
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
-        +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
-        +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +test_framework:TUF
+        +external_files:targetfiles_maser_test.pw9p2hdm_sentry.pcl.0600.4500.mas.prn=41523808be9123726eb8063a1c9910774935b5ac2655990487314364ce4b1866
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_targetfiles_maser_test_pw9p2hdm_sentry_pcl_0600_4500_mas_prn_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,30 +51,14 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title:test_pcl5_targetfiles_maser_test_pw9p2hdm_sentry_pcl_0600_4500_mas_prn
+            +guid:fbeb20da-2439-46fa-85b5-d2ea80ad6c9f
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
-
-        +overrides:
-            +Enterprise:
-                +is_manual:False
-                +timeout:600
-                +test:
-                    +dut:
-                        +type:Emulator
-
-
+                +configuration:DocumentFormat=PCL5 & JobStorageMedium=HardDisk
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
+    def test_when_using_pcl5_targetfiles_maser_test_pw9p2hdm_sentry_pcl_0600_4500_mas_prn_file_then_succeeds(self):
+        job_id = self.print.raw.start('41523808be9123726eb8063a1c9910774935b5ac2655990487314364ce4b1866')
         self.print.wait_for_job_completion(job_id)
         self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"

--- a/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_basicfunctionality_14page_udssval.py
+++ b/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_basicfunctionality_14page_udssval.py
@@ -1,0 +1,88 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from tests.network.print.ipp_utils import get_supported_job_preset_name_dict
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: IPP test for printing pcl5 basicfunctionality using 14Page-udssval.obj with attribute value
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-148958
+        +timeout:360
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:14Page-udssval.obj=380b283d10af04c5211e83373bd2a8bc1e598bc5906d5d0bcf625b6d0737a124
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pdl_intent_ipp_pcl5_basicfunctionality_14page_udssval_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pdl_intent_ipp_pcl5_basicfunctionality_14page_udssval
+            +guid:3fdea980-d545-495a-b754-431d47d34e8f
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5 & PrintProtocols=IPP & MediaSizeSupported=na_letter_8.5x11in & PrintColorMode=GrayScale & Print=Best & MediaType=Plain & MediaInputInstalled=Tray2 & PrintResolution=Print600 & Duplexer=True
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pdl_intent_ipp_pcl5_basicfunctionality_14page_udssval_file_then_succeeds(self):
+        if self.media.is_size_supported('na_letter_8.5x11in', 'tray-2'):
+            self.media.tray.configure_tray('tray-2', 'na_letter_8.5x11in', 'stationery')
+        job_preset_names = get_supported_job_preset_name_dict(printjob.ip_address)
+        print_quality_high = 5
+        ipp_test_attribs = {'document-format': 'application/vnd.hp-PCL5', 'media': 'na_letter_8.5x11in', 'print-color-mode': 'process-monochrome', 'print-quality': print_quality_high, 'copies':2, 'media-source': 'tray-2', 'media-type': 'stationery' , 'resolution': '600x600dpi', 'orientation-requested': 3, 'sides': 'two-sided-short-edge'}
+        ipp_test_file = printjob.generate_ipp_test(**ipp_test_attribs)
+
+        printjob.ipp_print(ipp_test_file, '380b283d10af04c5211e83373bd2a8bc1e598bc5906d5d0bcf625b6d0737a124', timeout=300)
+        outputverifier.save_and_parse_output()
+        outputverifier.verify_page_count(Intents.printintent, 28)
+        outputverifier.verify_collated_copies(Intents.printintent, 1)
+        outputverifier.verify_uncollated_copies(Intents.printintent, 2)
+        outputverifier.verify_media_size(Intents.printintent, MediaSize.letter)
+        outputverifier.verify_color_mode(Intents.printintent, ColorMode.grayscale)
+        outputverifier.verify_content_orientation(Intents.printintent, ContentOrientation.portrait)
+        outputverifier.verify_color_rendering(Intents.printintent, ColorRenderingType.gray)
+        outputverifier.verify_plex(Intents.printintent, Plex.duplex)
+        outputverifier.verify_print_quality(Intents.printintent, PrintQuality[job_preset_names[print_quality_high]])
+        outputverifier.verify_media_type(Intents.printintent, MediaType.stationery)
+        outputverifier.verify_media_source(Intents.printintent, MediaSource.tray2)
+        outputverifier.verify_plex_binding(Intents.printintent, PlexBinding.short_edge)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_basicfunctionality_1page_fpri600.py
+++ b/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_basicfunctionality_1page_fpri600.py
@@ -1,0 +1,89 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from tests.network.print.ipp_utils import get_supported_job_preset_name_dict
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:IPP test for printing a pcl5 basic functionality using 1Page-fpri600.obj with attribute value
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-148958
+        +timeout:180
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:1Page-fpri600.obj=980cabbf08033824f1375b2ffc25963578d63833a42e3a1d20321495d35186b4
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pdl_intent_ipp_pcl5_basicfunctionality_1page_fpri600_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pdl_intent_ipp_pcl5_basicfunctionality_1page_fpri600
+            +guid:4507f160-faa7-4454-9ffb-165379a90b1a
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5 & PrintProtocols=IPP & MediaSizeSupported=na_index-4x6_4x6in & PrintColorMode=Color & Print=Best & MediaType=HPTri-foldBrochureGlossy150g & MediaInputInstalled=Tray1 & PrintResolution=Print600
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pdl_intent_ipp_pcl5_basicfunctionality_1page_fpri600_file_then_succeeds(self):
+        if self.media.is_size_supported('na_index-4x6_4x6in', 'tray-1'):
+            self.media.tray.configure_tray('tray-1', 'na_index-4x6_4x6in', 'com.hp-trifold-brochure-glossy-150gsm')
+        job_preset_names = get_supported_job_preset_name_dict(printjob.ip_address)
+        print_quality_high = 5
+        ipp_test_attribs = {'document-format': 'application/vnd.hp-PCL5', 'media': 'na_index-4x6_4x6in', 'print-color-mode': 'color', 'print-quality': print_quality_high, 'copies':2, 'sides': 'one-sided', 'media-source': 'tray-1', 'media-type': 'com.hp-trifold-brochure-glossy-150gsm' , 'orientation-requested': 4, 'resolution': '600x600dpi'}
+        ipp_test_file = printjob.generate_ipp_test(**ipp_test_attribs)
+
+        printjob.ipp_print(ipp_test_file, '980cabbf08033824f1375b2ffc25963578d63833a42e3a1d20321495d35186b4')
+        outputverifier.save_and_parse_output()
+        outputverifier.verify_page_count(Intents.printintent, 1)
+        outputverifier.verify_collated_copies(Intents.printintent, 1)
+        outputverifier.verify_uncollated_copies(Intents.printintent, 2)
+        outputverifier.verify_media_size(Intents.printintent, MediaSize.photo4x6)
+        outputverifier.verify_color_mode(Intents.printintent, ColorMode.color)
+        outputverifier.verify_content_orientation(Intents.printintent, ContentOrientation.landscape)
+        outputverifier.verify_color_rendering(Intents.printintent, ColorRenderingType.office_rgb)
+        outputverifier.verify_plex(Intents.printintent, Plex.simplex)
+        outputverifier.verify_print_quality(Intents.printintent, PrintQuality[job_preset_names[print_quality_high]])
+        outputverifier.verify_media_type(Intents.printintent, MediaType.hptrifoldglossy150g)
+        outputverifier.verify_media_source(Intents.printintent, MediaSource.tray1)
+        outputverifier.verify_plex_binding(Intents.printintent, PlexBinding.one_sided)
+        outputverifier.verify_resolution(Intents.printintent, 600)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_basicfunctionality_20page_pm.py
+++ b/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_basicfunctionality_20page_pm.py
@@ -1,0 +1,88 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from tests.network.print.ipp_utils import get_supported_job_preset_name_dict
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: IPP test for printing pcl5 basicfunctionality using 20Page_pm.obj with attribute value
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-148958
+        +timeout:660
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:20Page-pm.obj=f51571bafe5ed95f2f4e8e4bb9dcd3877e52a1b360065804a404e3f1512b47a8
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pdl_intent_ipp_pcl5_basicfunctionality_20page_pm_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pdl_intent_ipp_pcl5_basicfunctionality_20page_pm
+            +guid:42cb3127-7eb9-4de0-a5ff-04b0d9b306ea
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5 & PrintProtocols=IPP & MediaSizeSupported=iso_a4_210x297mm & PrintColorMode=Color & Print=Best & MediaType=Plain & MediaInputInstalled=Tray1 & PrintResolution=Print600 & Duplexer=True
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pdl_intent_ipp_pcl5_basicfunctionality_20page_pm_file_then_succeeds(self):
+        if self.media.is_size_supported('iso_a4_210x297mm', 'tray-1'):
+            self.media.tray.configure_tray('tray-1', 'iso_a4_210x297mm', 'stationery')
+        job_preset_names = get_supported_job_preset_name_dict(printjob.ip_address)
+        print_quality_high = 5
+        ipp_test_attribs = {'document-format': 'application/vnd.hp-PCL5', 'media': 'iso_a4_210x297mm', 'print-color-mode': 'color', 'print-quality': print_quality_high, 'copies': 2, 'media-source': 'tray-1', 'media-type': 'stationery' , 'resolution': '600x600dpi', 'orientation-requested': 3, 'sides': 'two-sided-long-edge'}
+        ipp_test_file = printjob.generate_ipp_test(**ipp_test_attribs)
+
+        printjob.ipp_print(ipp_test_file, 'f51571bafe5ed95f2f4e8e4bb9dcd3877e52a1b360065804a404e3f1512b47a8', timeout=600)
+        outputverifier.save_and_parse_output()
+        outputverifier.verify_page_count(Intents.printintent, 24)
+        outputverifier.verify_collated_copies(Intents.printintent, 1)
+        outputverifier.verify_uncollated_copies(Intents.printintent, 2)
+        outputverifier.verify_media_size(Intents.printintent, MediaSize.a4)
+        outputverifier.verify_color_mode(Intents.printintent, ColorMode.color)
+        outputverifier.verify_content_orientation(Intents.printintent, ContentOrientation.portrait)
+        outputverifier.verify_color_rendering(Intents.printintent, ColorRenderingType.office_rgb)
+        outputverifier.verify_plex(Intents.printintent, Plex.duplex)
+        outputverifier.verify_print_quality(Intents.printintent, PrintQuality[job_preset_names[print_quality_high]])
+        outputverifier.verify_media_type(Intents.printintent, MediaType.stationery)
+        outputverifier.verify_media_source(Intents.printintent, MediaSource.tray1)
+        outputverifier.verify_plex_binding(Intents.printintent, PlexBinding.long_edge)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_basicfunctionality_3page_tr_tt.py
+++ b/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_basicfunctionality_3page_tr_tt.py
@@ -1,0 +1,88 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:IPP test for printing a pcl5 basicfunctionality using 3Page-tr_tt.obj with attribute value
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-148958
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:3Page-tr_tt.obj=e5ef10052d66481d7a965a8fcc2f13277ac1e06316a525d09ec6aa647b2b135e
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pdl_intent_ipp_pcl5_basicfunctionality_3page_tr_tt_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pdl_intent_ipp_pcl5_basicfunctionality_3page_tr_tt
+            +guid:2ce1409a-83ee-46fb-94f8-88a22599fb28
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5 & PrintProtocols=IPP & MediaSizeSupported=na_index-4x6_4x6in & PrintColorMode=BlackOnly & Print=Normal & MediaType=Plain & MediaInputInstalled=Tray1 & PrintResolution=Print600
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pdl_intent_ipp_pcl5_basicfunctionality_3page_tr_tt_file_then_succeeds(self):
+        if self.media.is_size_supported('na_index-4x6_4x6in', 'tray-1'):
+            self.media.tray.configure_tray('tray-1', 'na_index-4x6_4x6in', 'stationery')
+
+        ipp_test_attribs = {'document-format': 'application/vnd.hp-PCL5', 'media': 'na_index-4x6_4x6in', 'print-color-mode': 'monochrome', 'print-quality': 4, 'copies':1, 'media-source': 'tray-1', 'media-type': 'stationery' , 'resolution': '600x600dpi', 'orientation-requested': 3, 'sides': 'one-sided'}
+        ipp_test_file = printjob.generate_ipp_test(**ipp_test_attribs)
+
+        printjob.ipp_print(ipp_test_file, 'e5ef10052d66481d7a965a8fcc2f13277ac1e06316a525d09ec6aa647b2b135e')
+        outputverifier.save_and_parse_output()
+        outputverifier.verify_page_count(Intents.printintent, 3)
+        outputverifier.verify_collated_copies(Intents.printintent, 1)
+        outputverifier.verify_uncollated_copies(Intents.printintent, 1)
+        outputverifier.verify_media_size(Intents.printintent, MediaSize.photo4x6)
+        outputverifier.verify_color_mode(Intents.printintent, ColorMode.monochrome)
+        outputverifier.verify_content_orientation(Intents.printintent, ContentOrientation.portrait)
+        outputverifier.verify_color_rendering(Intents.printintent, ColorRenderingType.gray)
+        outputverifier.verify_plex(Intents.printintent, Plex.simplex)
+        outputverifier.verify_print_quality(Intents.printintent, PrintQuality.normal)
+        outputverifier.verify_media_type(Intents.printintent, MediaType.stationery)
+        outputverifier.verify_media_source(Intents.printintent, MediaSource.tray1)
+        outputverifier.verify_plex_binding(Intents.printintent, PlexBinding.one_sided)
+        outputverifier.verify_resolution(Intents.printintent, 600)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_highvalue_13page_bt0_300.py
+++ b/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_highvalue_13page_bt0_300.py
@@ -1,0 +1,88 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from tests.network.print.ipp_utils import get_supported_job_preset_name_dict
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: IPP test for printing a pcl5 highvalue using 13Page-bt0_300.obj with attribute value
+        +test_tier: 1
+        +is_manual:False
+        +test_classification: 1
+        +reqid: DUNE-148958
+        +timeout:660
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:13Page-bt0_300.obj=6d3db5e306905991d140cfe463aaecca8be45633175a850cad41c241028597c3
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pdl_intent_ipp_pcl5_highvalue_13page_bt0_300_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pdl_intent_ipp_pcl5_highvalue_13page_bt0_300
+            +guid:b28d9cbd-2bab-4c16-9f6a-94e3c47ae826
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5 & PrintProtocols=IPP & MediaSizeSupported=na_index-4x6_4x6in & PrintColorMode=Color & Print=Best & MediaType=Plain & MediaInputInstalled=Tray1 & PrintResolution=Print600 & EngineFirmwareFamily=Canon
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pdl_intent_ipp_pcl5_highvalue_13page_bt0_300_file_then_succeeds(self):
+        if self.media.is_size_supported('na_index-4x6_4x6in', 'tray-1'):
+            self.media.tray.configure_tray('tray-1', 'na_index-4x6_4x6in', 'stationery')
+        job_preset_names = get_supported_job_preset_name_dict(printjob.ip_address)
+        print_quality_high = 5
+        ipp_test_attribs = {'document-format': 'application/vnd.hp-PCL5', 'media': 'na_index-4x6_4x6in', 'print-color-mode': 'color', 'print-quality': print_quality_high, 'copies':2, 'sides': 'one-sided', 'media-source': 'tray-1', 'media-type': 'stationery' , 'orientation-requested': 3, 'resolution': '600x600dpi'}
+        ipp_test_file = printjob.generate_ipp_test(**ipp_test_attribs)
+
+        printjob.ipp_print(ipp_test_file, '6d3db5e306905991d140cfe463aaecca8be45633175a850cad41c241028597c3', timeout=700)
+        outputverifier.save_and_parse_output()
+        outputverifier.verify_page_count(Intents.printintent, 13)
+        outputverifier.verify_collated_copies(Intents.printintent, 1)
+        outputverifier.verify_uncollated_copies(Intents.printintent, 2)
+        outputverifier.verify_media_size(Intents.printintent, MediaSize.photo4x6)
+        outputverifier.verify_color_mode(Intents.printintent, ColorMode.color)
+        outputverifier.verify_content_orientation(Intents.printintent, ContentOrientation.portrait)
+        outputverifier.verify_color_rendering(Intents.printintent, ColorRenderingType.office_rgb)
+        outputverifier.verify_plex(Intents.printintent, Plex.simplex)
+        outputverifier.verify_print_quality(Intents.printintent, PrintQuality[job_preset_names[print_quality_high]])
+        outputverifier.verify_media_type(Intents.printintent, MediaType.stationery)
+        outputverifier.verify_media_source(Intents.printintent, MediaSource.tray1)
+        outputverifier.verify_plex_binding(Intents.printintent, PlexBinding.one_sided)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_highvalue_1page_clip_pm.py
+++ b/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_highvalue_1page_clip_pm.py
@@ -1,0 +1,88 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from tests.network.print.ipp_utils import get_supported_job_preset_name_dict
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: IPP test for printing pcl5 highvalue using 1Page-clip_pm.obj with attribute value
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-148958
+        +timeout:180
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:1Page-clip_pm.obj=4a0f46abc1cb3616c725f8c255dfa89a07b84110e37a4f74a8f7f265daa6752b
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pdl_intent_ipp_pcl5_highvalue_1page_clip_pm_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pdl_intent_ipp_pcl5_highvalue_1page_clip_pm
+            +guid:2bf999d1-5124-4df9-a142-c4c3aa5da666
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5 & PrintProtocols=IPP & MediaSizeSupported=na_monarch_3.875x7.5in & PrintColorMode=Color & Print=Best & MediaType=Plain & MediaInputInstalled=Tray1 & PrintResolution=Print600
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pdl_intent_ipp_pcl5_highvalue_1page_clip_pm_file_then_succeeds(self):
+        if self.media.is_size_supported('na_monarch_3.875x7.5in', 'tray-1'):
+            self.media.tray.configure_tray('tray-1', 'na_monarch_3.875x7.5in', 'stationery')
+        job_preset_names = get_supported_job_preset_name_dict(printjob.ip_address)
+        print_quality_high = 5
+        ipp_test_attribs = {'document-format': 'application/vnd.hp-PCL5', 'media': 'na_monarch_3.875x7.5in','print-color-mode': 'color', 'print-quality': print_quality_high, 'copies':2, 'sides': 'one-sided', 'media-source': 'tray-1', 'orientation-requested': 3, 'media-type': 'stationery', 'resolution': '600x600dpi'}
+        ipp_test_file = printjob.generate_ipp_test(**ipp_test_attribs)
+
+        printjob.ipp_print(ipp_test_file, '4a0f46abc1cb3616c725f8c255dfa89a07b84110e37a4f74a8f7f265daa6752b',timeout=300)
+        outputverifier.save_and_parse_output()
+        outputverifier.verify_page_count(Intents.printintent, 1)
+        outputverifier.verify_collated_copies(Intents.printintent, 1)
+        outputverifier.verify_uncollated_copies(Intents.printintent, 2)
+        outputverifier.verify_media_size(Intents.printintent, MediaSize.monarchenvelope)
+        outputverifier.verify_color_mode(Intents.printintent, ColorMode.color)
+        outputverifier.verify_content_orientation(Intents.printintent, ContentOrientation.portrait)
+        outputverifier.verify_color_rendering(Intents.printintent, ColorRenderingType.office_rgb)
+        outputverifier.verify_plex(Intents.printintent, Plex.simplex)
+        outputverifier.verify_print_quality(Intents.printintent, PrintQuality[job_preset_names[print_quality_high]])
+        outputverifier.verify_media_type(Intents.printintent, MediaType.stationery)
+        outputverifier.verify_media_source(Intents.printintent, MediaSource.tray1)
+        outputverifier.verify_plex_binding(Intents.printintent, PlexBinding.one_sided)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_highvalue_2page_clip_coordsys.py
+++ b/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_highvalue_2page_clip_coordsys.py
@@ -1,0 +1,88 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from tests.network.print.ipp_utils import get_supported_job_preset_name_dict
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: IPP test for printing pcl5 highvalue using 2Page-clip_coordsys.obj with attribute value
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-148958
+        +timeout:660
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:2Page-clip_coordsys.obj=27705d4558867a38616e6bb0849288b263f260f462e8296da1765b9c0e208bd6
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pdl_intent_ipp_pcl5_highvalue_2page_clip_coordsys_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pdl_intent_ipp_pcl5_highvalue_2page_clip_coordsys
+            +guid:fb3c82d6-9e03-45b0-b08a-772e16bccf1a
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5 & PrintProtocols=IPP & MediaSizeSupported=om_16k_184x260mm & PrintColorMode=Color & Print=Best & MediaType=HPBrochureMatte150g & MediaInputInstalled=Tray1 & PrintResolution=Print600 & Duplexer=True
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pdl_intent_ipp_pcl5_highvalue_2page_clip_coordsys_file_then_succeeds(self):
+        if self.media.is_size_supported('om_16k_184x260mm', 'tray-1'):
+            self.media.tray.configure_tray('tray-1', 'om_16k_184x260mm', 'com.hp.matte-160gsm')
+        job_preset_names = get_supported_job_preset_name_dict(printjob.ip_address)
+        print_quality_high = 5
+        ipp_test_attribs = {'document-format': 'application/vnd.hp-PCL5', 'media': 'om_16k_184x260mm', 'print-color-mode': 'color', 'print-quality': print_quality_high, 'copies':2, 'media-source': 'tray-1', 'orientation-requested': 3, 'media-type': 'com.hp.matte-160gsm', 'resolution': '600x600dpi', 'sides': 'one-sided'}
+        ipp_test_file = printjob.generate_ipp_test(**ipp_test_attribs)
+
+        printjob.ipp_print(ipp_test_file, '27705d4558867a38616e6bb0849288b263f260f462e8296da1765b9c0e208bd6', timeout=600)
+        outputverifier.save_and_parse_output()
+        outputverifier.verify_page_count(Intents.printintent, 2)
+        outputverifier.verify_collated_copies(Intents.printintent, 1)
+        outputverifier.verify_uncollated_copies(Intents.printintent, 2)
+        outputverifier.verify_media_size(Intents.printintent, MediaSize.media16k_184x260)
+        outputverifier.verify_color_mode(Intents.printintent, ColorMode.color)
+        outputverifier.verify_content_orientation(Intents.printintent, ContentOrientation.portrait)
+        outputverifier.verify_color_rendering(Intents.printintent, ColorRenderingType.office_rgb)
+        outputverifier.verify_plex(Intents.printintent, Plex.simplex)
+        outputverifier.verify_print_quality(Intents.printintent, PrintQuality[job_preset_names[print_quality_high]])
+        outputverifier.verify_media_type(Intents.printintent, MediaType.hpmatte150g)
+        outputverifier.verify_media_source(Intents.printintent, MediaSource.tray1)
+        outputverifier.verify_plex_binding(Intents.printintent, PlexBinding.one_sided)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_highvalue_4page_arial.py
+++ b/pcl5_new/test_when_printing_pdl_intent_ipp_pcl5_highvalue_4page_arial.py
@@ -1,0 +1,88 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from dunetuf.print.output.intents import Intents, MediaSize, ColorMode, PrintQuality, ColorRenderingType, ContentOrientation, Plex, MediaType, MediaSource, PlexBinding
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: IPP test for printing pcl5 highvalue using 4Page-arial.obj with attribute value
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-148958
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:4Page-arial.obj=c74922027034624c176f82abd10e72e375b8a81ae68fdcdc37af09797d546468
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pdl_intent_ipp_pcl5_highvalue_4page_arial_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pdl_intent_ipp_pcl5_highvalue_4page_arial
+            +guid:7fba3b02-3e79-40b8-b48c-c7dee5095e13
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5 & PrintProtocols=IPP & MediaSizeSupported=na_executive_7.25x10.5in & PrintColorMode=GrayScale & Print=Normal & MediaType=Plain & MediaInputInstalled=Tray1 & PrintResolution=Print600
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pdl_intent_ipp_pcl5_highvalue_4page_arial_file_then_succeeds(self):
+        if self.media.is_size_supported('na_executive_7.25x10.5in', 'tray-1'):
+            self.media.tray.configure_tray('tray-1', 'na_executive_7.25x10.5in', 'stationery')
+
+        ipp_test_attribs = {'document-format': 'application/vnd.hp-PCL5', 'media': 'na_executive_7.25x10.5in','print-color-mode': 'process-monochrome', 'print-quality': 4, 'copies':1, 'sides': 'one-sided', 'media-source': 'tray-1', 'orientation-requested': 3, 'media-type': 'stationery', 'resolution': '600x600dpi'}
+        ipp_test_file = printjob.generate_ipp_test(**ipp_test_attribs)
+
+        printjob.ipp_print(ipp_test_file, 'c74922027034624c176f82abd10e72e375b8a81ae68fdcdc37af09797d546468')
+        outputverifier.save_and_parse_output()
+        outputverifier.verify_page_count(Intents.printintent, 4)
+        outputverifier.verify_collated_copies(Intents.printintent, 1)
+        outputverifier.verify_uncollated_copies(Intents.printintent, 1)
+        outputverifier.verify_media_size(Intents.printintent, MediaSize.executive)
+        outputverifier.verify_color_mode(Intents.printintent, ColorMode.grayscale)
+        outputverifier.verify_content_orientation(Intents.printintent, ContentOrientation.portrait)
+        outputverifier.verify_color_rendering(Intents.printintent, ColorRenderingType.gray)
+        outputverifier.verify_plex(Intents.printintent, Plex.simplex)
+        outputverifier.verify_print_quality(Intents.printintent, PrintQuality.normal)
+        outputverifier.verify_media_type(Intents.printintent, MediaType.stationery)
+        outputverifier.verify_media_source(Intents.printintent, MediaSource.tray1)
+        outputverifier.verify_plex_binding(Intents.printintent, PlexBinding.one_sided)
+        outputverifier.verify_resolution(Intents.printintent, 600)
+        self.outputsaver.save_output()
+        self.outputsaver.operation_mode('NONE')
+        self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pdl_intent_pcl5_duplex_longedge_mediasource_tray1_2page.py
+++ b/pcl5_new/test_when_printing_pdl_intent_pcl5_duplex_longedge_mediasource_tray1_2page.py
@@ -1,0 +1,89 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from dunetuf.print.output.intents import Intents, MediaSize, MediaType, MediaSource, Plex, PlexBinding
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Print a PCL5 test file with media source command specified with tray1, plex command specified with duplex long edge and ensure PDL is processing the job with tray1 and producing duplex long edge output
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-183335, DUNE-187154
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:pcl5_duplex_longedge_tray1.prn=d375b13a581607e4562b116af4585f5523757f255463204a43a6ce654e2080c0
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pdl_intent_pcl5_duplex_longedge_mediasource_tray1_2page_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pdl_intent_pcl5_duplex_longedge_mediasource_tray1_2page
+            +guid:331f6bea-8bd5-4ff0-8f7c-877ecc90771b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5 & MediaInputInstalled=Tray1 & MediaSizeSupported=na_letter_8.5x11in & Duplexer=True
+
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pdl_intent_pcl5_duplex_longedge_mediasource_tray1_2page_file_then_succeeds(self):
+        if tray.is_tray_supported('tray-1') and self.media.is_size_supported('na_letter_8.5x11in', 'tray-1'):
+            self.media.tray.configure_tray('tray-1', 'na_letter_8.5x11in', 'stationery')
+            job_id = self.print.raw.start('d375b13a581607e4562b116af4585f5523757f255463204a43a6ce654e2080c0')
+            self.print.wait_for_job_completion(job_id)
+            outputverifier.save_and_parse_output()
+            outputverifier.verify_plex(Intents.printintent, Plex.duplex)
+            outputverifier.verify_plex_binding(Intents.printintent, PlexBinding.long_edge)
+            outputverifier.verify_page_count(Intents.printintent, 2)
+            outputverifier.verify_collated_copies(Intents.printintent, 1)
+            outputverifier.verify_uncollated_copies(Intents.printintent, 1)
+            outputverifier.verify_media_size(Intents.printintent, MediaSize.letter)
+            outputverifier.verify_media_type(Intents.printintent, MediaType.stationery)
+            outputverifier.verify_media_source(Intents.printintent, MediaSource.tray1)
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pdl_intent_pcl5_duplex_shortedge_mediasource_tray2_2page.py
+++ b/pcl5_new/test_when_printing_pdl_intent_pcl5_duplex_shortedge_mediasource_tray2_2page.py
@@ -1,0 +1,80 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from dunetuf.print.output.intents import Intents, MediaSize, MediaType, MediaSource, Plex, PlexBinding
+
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose:Print a PCL5 test file with media source command specified with tray2, plex command specified with duplex short edge and ensure PDL is processing the job with tray2 and producing duplex short edge output
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-183335, DUNE-187154
+        +timeout:120
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:pcl5_duplex_shortedge_tray2.prn=4011e2a4035841c2b451ce07faf2dfda45e9311513a80ea036c5b440705ebb65
+        +test_classification:Systems
+        +name:TestWhenPrintingJPEGFile::test_when_using_pdl_intent_pcl5_duplex_shortedge_mediasource_tray2_2page_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pdl_intent_pcl5_duplex_shortedge_mediasource_tray2_2page
+            +guid:1b7be8bf-46ac-474a-8533-f8e5968e623d
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5 & MediaInputInstalled=Tray2 & MediaSizeSupported=na_letter_8.5x11in & Duplexer=True
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pdl_intent_pcl5_duplex_shortedge_mediasource_tray2_2page_file_then_succeeds(self):
+        if tray.is_tray_supported('tray-2') and self.media.is_size_supported('na_letter_8.5x11in', 'tray-2'):
+            self.media.tray.configure_tray('tray-2', 'na_letter_8.5x11in', 'stationery')
+            job_id = self.print.raw.start('4011e2a4035841c2b451ce07faf2dfda45e9311513a80ea036c5b440705ebb65')
+            self.print.wait_for_job_completion(job_id)
+            outputverifier.save_and_parse_output()
+            outputverifier.verify_page_count(Intents.printintent, 2)
+            outputverifier.verify_plex(Intents.printintent, Plex.duplex)
+            outputverifier.verify_plex_binding(Intents.printintent, PlexBinding.short_edge)
+            outputverifier.verify_collated_copies(Intents.printintent, 1)
+            outputverifier.verify_uncollated_copies(Intents.printintent, 1)
+            outputverifier.verify_media_size(Intents.printintent, MediaSize.letter)
+            outputverifier.verify_media_type(Intents.printintent, MediaType.stationery)
+            outputverifier.verify_media_source(Intents.printintent, MediaSource.tray2)
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            self.media.tray.reset_trays()

--- a/pcl5_new/test_when_printing_pdl_intent_pcl5_mediasource_tray3_1page.py
+++ b/pcl5_new/test_when_printing_pdl_intent_pcl5_mediasource_tray3_1page.py
@@ -2,6 +2,8 @@ import logging
 from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
 from dunetuf.print.new.output.output_saver import OutputSaver
 from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+from dunetuf.print.output.intents import Intents, MediaSize, MediaType, MediaSource
+
 
 class TestWhenPrintingJPEGFile(TestWhenPrinting):
     @classmethod
@@ -30,19 +32,19 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
         tear_down_output_saver(self.outputsaver)
     """
     $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
-        +purpose: pcl5 lowvaluenew using 8Page_gl.obj
+        +purpose:Print a PCL5 test file with media source command specified with tray3 and ensure PDL is processing the job with tray3
         +test_tier: 1
         +is_manual: False
         +test_classification: 1
-        +reqid: DUNE-37356
-        +timeout:600
+        +reqid: DUNE-183335
+        +timeout:120
         +asset:PDL_New
         +delivery_team:QualityGuild
         +feature_team:PDLSolns
         +test_framework: TUF
-        +external_files:8Page-gl.obj=c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6
+        +external_files:Tray3.prn=3310656b796a1c221d51b6b7c9794cbcb5544e45b17100f0c702b36d39a84218
         +test_classification:System
-        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds
+        +name:TestWhenPrintingJPEGFile::test_when_using_pdl_intent_pcl5_mediasource_tray3_1page_file_then_succeeds
         +categorization:
             +segment:Platform
             +area:Print
@@ -51,11 +53,11 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
             +interaction:Headless
             +test_type:Positive
         +test:
-            +title: test_pcl5_lowvaluenew_8page_gl
-            +guid:ed989029-303f-43ff-beec-cc2483221990
+            +title: test_pdl_intent_pcl5_mediasource_tray3_1page
+            +guid:85b829bd-f634-4427-a9e9-30a3805c5386
             +dut:
                 +type:Simulator
-                +configuration: DocumentFormat=PCL5
+                +configuration: DocumentFormat=PCL5 & MediaInputInstalled=Tray3 & MediaSizeSupported=na_letter_8.5x11in
 
         +overrides:
             +Enterprise:
@@ -68,13 +70,18 @@ class TestWhenPrintingJPEGFile(TestWhenPrinting):
 
     $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
     """
-    def test_when_using_pcl5_lowvaluenew_8page_gl_file_then_succeeds(self):
-        self.outputsaver.validate_crc_tiff()
-        job_id = self.print.raw.start('c61e9d843177429bea0da78aa5b48154203ceb6e8eaffd935dd93115d90096a6')
-        self.print.wait_for_job_completion(job_id)
-        self.outputsaver.save_output()
-        self.outputsaver.operation_mode('NONE')
-        logging.info("Get crc value for the current print job")
-        Current_crc_value = self.outputsaver.get_crc()
-        logging.info("Validate current crc with master crc")
-        assert self.outputsaver.verify_pdl_crc(Current_crc_value), "fail on crc mismatch"
+    def test_when_using_pdl_intent_pcl5_mediasource_tray3_1page_file_then_succeeds(self):
+        if tray.is_tray_supported('tray-3') and self.media.is_size_supported('na_letter_8.5x11in', 'tray-3'):
+            self.media.tray.configure_tray('tray-3', 'na_letter_8.5x11in', 'stationery')
+            job_id = self.print.raw.start('3310656b796a1c221d51b6b7c9794cbcb5544e45b17100f0c702b36d39a84218')
+            self.print.wait_for_job_completion(job_id)
+            outputverifier.save_and_parse_output()
+            outputverifier.verify_page_count(Intents.printintent, 1)
+            outputverifier.verify_collated_copies(Intents.printintent, 1)
+            outputverifier.verify_uncollated_copies(Intents.printintent, 1)
+            outputverifier.verify_media_size(Intents.printintent, MediaSize.letter)
+            outputverifier.verify_media_type(Intents.printintent, MediaType.stationery)
+            outputverifier.verify_media_source(Intents.printintent, MediaSource.tray3)
+            self.outputsaver.save_output()
+            self.outputsaver.operation_mode('NONE')
+            self.media.tray.reset_trays()

--- a/scripts/convert_root.py
+++ b/scripts/convert_root.py
@@ -1,0 +1,139 @@
+import os, re, uuid, textwrap
+
+src_dir = 'pcl5'
+dst_dir = 'pcl5_new'
+os.makedirs(dst_dir, exist_ok=True)
+
+files = [f for f in os.listdir(src_dir) if f.endswith('.py')]
+
+for fname in files:
+    base = fname[len('test_'):-3]
+    new_fname = f'test_when_printing_{base}.py'
+    dst_path = os.path.join(dst_dir, new_fname)
+    if os.path.exists(dst_path):
+        continue
+    with open(os.path.join(src_dir, fname)) as f:
+        content = f.read()
+
+    # gather extra imports before metadata
+    pre_meta, rest = content.split('"""', 1)
+    import_lines = []
+    for line in pre_meta.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith('import pytest'):
+            continue
+        import_lines.append(line)
+
+    # mandatory imports
+    imports = [
+        'import logging',
+        'from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType',
+        'from dunetuf.print.new.output.output_saver import OutputSaver',
+        'from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver',
+    ]
+    for line in import_lines:
+        if line not in imports:
+            imports.append(line)
+    import_block = '\n'.join(imports)
+
+    meta_match = re.search(r'(\$\$\$\$\$_BEGIN_TEST_METADATA_DECLARATION_\$\$\$\$\$.*?\$\$\$\$\$_END_TEST_METADATA_DECLARATION_\$\$\$\$\$)', content, re.S)
+    if not meta_match:
+        raise ValueError(f'Metadata block not found in {fname}')
+    metadata = meta_match.group(1)
+
+    lines = []
+    for line in metadata.splitlines():
+        if '+asset:' in line:
+            line = re.sub(r'\+asset:.*', '+asset:PDL_New', line)
+        if '+delivery_team:' in line:
+            line = re.sub(r'\+delivery_team:.*', '+delivery_team:QualityGuild', line)
+        if re.search(r'\+name:', line):
+            indent = line[:line.find('+')]
+            line = f"{indent}+name:TestWhenPrintingJPEGFile::test_when_using_{base}_file_then_succeeds"
+        if re.search(r'\+guid:', line):
+            indent = line[:line.find('+')]
+            line = f"{indent}+guid:{uuid.uuid4()}"
+        lines.append(line)
+    lines = ['    ' + ln for ln in lines]
+    metadata_new = '\n'.join(lines)
+
+    after_meta = content.split(meta_match.group(0))[-1]
+    func_match = re.search(r'def\s+test_[^(]+\(.*?\):\n([\s\S]*)', after_meta)
+    body = func_match.group(1) if func_match else ''
+    body = textwrap.dedent(body)
+
+    replacements = [
+        ('printjob.print_verify_multi', 'self.print.raw.start'),
+        ('printjob.print_verify', 'self.print.raw.start'),
+        ('printjob.start_print', 'self.print.raw.start'),
+        ('printjob.wait_for_job_completion', 'self.print.wait_for_job_completion'),
+        ('outputsaver.validate_crc_tiff(udw)', 'self.outputsaver.validate_crc_tiff()'),
+        ('outputsaver.validate_crc_tiff( udw )', 'self.outputsaver.validate_crc_tiff()'),
+        ('outputsaver.validate_crc_tiff', 'self.outputsaver.validate_crc_tiff'),
+        ('outputsaver.save_output()', 'self.outputsaver.save_output()'),
+        ('outputsaver.operation_mode', 'self.outputsaver.operation_mode'),
+        ('outputsaver.get_crc()', 'self.outputsaver.get_crc()'),
+        ('outputsaver.verify_pdl_crc', 'self.outputsaver.verify_pdl_crc'),
+        ('print_emulation.print_engine_platform', 'self.get_platform()'),
+        ('print_emulation.tray.', 'self.media.tray.'),
+        ('print_emulation.', 'self.media.'),
+        ('tray.get_default_source()', 'self.media.get_default_source()'),
+        ('tray.is_size_supported', 'self.media.is_size_supported'),
+        ('tray.configure_tray', 'self.media.tray.configure_tray'),
+        ('tray.reset_trays()', 'self.media.tray.reset_trays()'),
+        ('configuration.familyname', 'self.configuration.familyname'),
+    ]
+    for old, new in replacements:
+        body = body.replace(old, new)
+
+    orig_lines = body.splitlines()
+    body_lines = []
+    for line in orig_lines:
+        m = re.search(r"self.print.raw.start\('([0-9a-f]{32,})'", line)
+        if m:
+            checksum = m.group(1)
+            prefix = re.match(r'^\s*', line).group()
+            body_lines.append(f"{prefix}job_id = self.print.raw.start('{checksum}')")
+            body_lines.append(f"{prefix}self.print.wait_for_job_completion(job_id)")
+            continue
+        body_lines.append(line)
+    body = '\n'.join(body_lines)
+    body = '\n'.join(('        ' + l if l.strip() else '') for l in body.splitlines())
+
+    class_def = textwrap.dedent(f'''
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    {metadata_new}
+    """
+    def test_when_using_{base}_file_then_succeeds(self):
+{body}
+''')
+
+    with open(dst_path, 'w') as f:
+        f.write(import_block + '\n\n' + class_def)


### PR DESCRIPTION
## Summary
- convert all legacy PCL5 root tests to the new PDL_New style
- provide helper script to automate conversion
- fix metadata indentation and self reference issues in new PCL5 tests

## Testing
- `python3 -m py_compile $(git ls-files 'pcl5_new/**/*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688231fd3438833281e8d187e7ae9b13