### PR TITLE
Add next PCL5 jedi tests in new framework - part 2

### DIFF
--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_ascii.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_ascii.py
@@ -1,0 +1,67 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 allocidcoverage using ascii.pcl
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:ascii.pcl=eaf547ccd8476ba5757e2cb3c58b6f8b5f0a93fc54d674d2a7b4288155a5f7e6
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_allocidcoverage_ascii_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_allocidcoverage_ascii
+            +guid:3e9cd9c6-173b-4d19-af0d-1e5fe1328651
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_allocidcoverage_ascii_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('eaf547ccd8476ba5757e2cb3c58b6f8b5f0a93fc54d674d2a7b4288155a5f7e6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_comp0_3.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_comp0_3.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 allocidcoverage using comp0_3.pcl
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:comp0-3.pcl=4d1e0fa2faaf0fd4cdad6c105debf5f58f3a936a52b3c8c47a64675bb49e8460
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_allocidcoverage_comp0_3_file_then_succeeds
+        +test:
+            +title: test_pcl5_allocidcoverage_comp0_3
+            +guid:a1cfcb96-5579-44d4-b2df-17c1e23012cf
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_allocidcoverage_comp0_3_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('4d1e0fa2faaf0fd4cdad6c105debf5f58f3a936a52b3c8c47a64675bb49e8460')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_configure.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_configure.py
@@ -1,0 +1,67 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 allocidcoverage using configure.pcl
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:configure.pcl=ee655ab156898d558a4b886fb6153f6f28682b59b90e26a457fbbd4e8e3704b1
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_allocidcoverage_configure_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_allocidcoverage_configure
+            +guid:5de10104-fc15-4e64-bd9a-b496e791896f
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_allocidcoverage_configure_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('ee655ab156898d558a4b886fb6153f6f28682b59b90e26a457fbbd4e8e3704b1')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_dirpix.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_dirpix.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 allocidcoverage using dirpix.pcl
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:dirpix.pcl=8e42efbae87c2176a0708a980f26b466a9bd17be9683112c1b1b0bbd6bcae832
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_allocidcoverage_dirpix_file_then_succeeds
+        +test:
+            +title: test_pcl5_allocidcoverage_dirpix
+            +guid:35fc2a87-50b3-4078-ac40-39570ff53479
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_allocidcoverage_dirpix_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('8e42efbae87c2176a0708a980f26b466a9bd17be9683112c1b1b0bbd6bcae832')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_driver.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_driver.py
@@ -1,0 +1,67 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 allocidcoverage using driver.pcl
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:driver.pcl=b8bc13909c9e88ea4a648f5f866d2f2d7400b26c06ddcb4840e1d797a1a1b678
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_allocidcoverage_driver_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_allocidcoverage_driver
+            +guid:664bc847-9e2a-489c-ae35-2fa8f6956a44
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_allocidcoverage_driver_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('b8bc13909c9e88ea4a648f5f866d2f2d7400b26c06ddcb4840e1d797a1a1b678')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_fn.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_fn.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 allocidcoverage using fn.pcl
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:fn.pcl=454bc3615d2e10c0c23f77e350edadccaa51b9132722df35ca04c1006e08ca2a
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_allocidcoverage_fn_file_then_succeeds
+        +test:
+            +title: test_pcl5_allocidcoverage_fn
+            +guid:fb6696d1-8441-4aee-92fc-b9f5d20d8aeb
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_allocidcoverage_fn_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('454bc3615d2e10c0c23f77e350edadccaa51b9132722df35ca04c1006e08ca2a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_fontlist.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_fontlist.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 allocidcoverage using fontlist.pcl
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:fontlist.pcl=89f14da0945f81b02f3fe6f529727274921bcfb103df2ba05cc546796bc5ce7c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_allocidcoverage_fontlist_file_then_succeeds
+        +test:
+            +title: test_pcl5_allocidcoverage_fontlist
+            +guid:1301fd0e-e248-4396-a7e9-f0d4e88a9848
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_allocidcoverage_fontlist_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('89f14da0945f81b02f3fe6f529727274921bcfb103df2ba05cc546796bc5ce7c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_hello.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_hello.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 allocidcoverage using hello.pcl
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:hello.pcl=d8bb33a13b3dd0575411ff45377e258f2e970365e93351a0994b6619c2da7ed4
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_allocidcoverage_hello_file_then_succeeds
+        +test:
+            +title: test_pcl5_allocidcoverage_hello
+            +guid:c71e4b4a-c487-40da-a9c7-2f72578fe8a0
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_allocidcoverage_hello_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('d8bb33a13b3dd0575411ff45377e258f2e970365e93351a0994b6619c2da7ed4')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_pagecheck.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_pagecheck.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 allocidcoverage using PageCheck.pcl
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:PageCheck.pcl=0c8699a59acb1766e4fc39930efcf741e43a5d140467c333c3c043bab4fd3394
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_allocidcoverage_pagecheck_file_then_succeeds
+        +test:
+            +title: test_pcl5_allocidcoverage_pagecheck
+            +guid:6b374760-a47e-4beb-9443-1b5c658f6be3
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_allocidcoverage_pagecheck_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('0c8699a59acb1766e4fc39930efcf741e43a5d140467c333c3c043bab4fd3394')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_pageclip.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_pageclip.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 allocidcoverage using PageClip.pcl
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:PageClip.pcl=8ee06ba8d25ba3f1899f2065eb5d694abfb59153c493545796676261f0d7ab5e
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_allocidcoverage_pageclip_file_then_succeeds
+        +test:
+            +title: test_pcl5_allocidcoverage_pageclip
+            +guid:c3311f19-cf49-4bf5-b7bb-c97f5cf36913
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_allocidcoverage_pageclip_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('8ee06ba8d25ba3f1899f2065eb5d694abfb59153c493545796676261f0d7ab5e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_pushpoppal.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_pushpoppal.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 allocidcoverage using pushPopPal.pcl
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pushPopPal.pcl=937f220f1a1cee3019ba499f0dca294c38a01e1bd11fb7336697daaadc359de1
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_allocidcoverage_pushpoppal_file_then_succeeds
+        +test:
+            +title: test_pcl5_allocidcoverage_pushpoppal
+            +guid:5a9442c5-cc9d-4067-87ae-c48b7c3f4ac5
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_allocidcoverage_pushpoppal_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('937f220f1a1cee3019ba499f0dca294c38a01e1bd11fb7336697daaadc359de1')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_rf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_rf.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 allocidcoverage using rf.pcl
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:rf.pcl=dee626b17fdf9fc4c60ac50c5f19a42f57449c88439aaeaa38e82e88a36d4b7d
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_allocidcoverage_rf_file_then_succeeds
+        +test:
+            +title: test_pcl5_allocidcoverage_rf
+            +guid:0c29ec9f-75cb-4754-a169-62e828b5abdc
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_allocidcoverage_rf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('dee626b17fdf9fc4c60ac50c5f19a42f57449c88439aaeaa38e82e88a36d4b7d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_textvector.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_allocidcoverage_textvector.py
@@ -1,0 +1,67 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 allocidcoverage using TextVector.pcl
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:TextVector.pcl=ce90331a6a06cad7c333d480eb14a347d5b17d3c525ac73f5968064b96d15eac
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_allocidcoverage_textvector_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_allocidcoverage_textvector
+            +guid:0e84a476-33ce-4902-b95f-817386ddb638
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_allocidcoverage_textvector_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('ce90331a6a06cad7c333d480eb14a347d5b17d3c525ac73f5968064b96d15eac')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_alpine_pcl_macros_delet_nc.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_alpine_pcl_macros_delet_nc.py
@@ -1,0 +1,67 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 alpine using delet_nc.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:delet_nc.obj=68e35ae2f5b9e3d9612ee90221bdfd94477e8ea9ca58daf919887649ab29ab1f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_alpine_pcl_macros_delet_nc_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_alpine_pcl_macros_delet_nc
+            +guid:85c5a686-35f6-4990-9a73-323a7128a680
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_alpine_pcl_macros_delet_nc_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('68e35ae2f5b9e3d9612ee90221bdfd94477e8ea9ca58daf919887649ab29ab1f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_app_aptest_2.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_app_aptest_2.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 app using aptest_2.obj
+        +test_tier: 3
+        +is_manual:False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:360
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:aptest_2.obj=e5002a538d0fa1b3573f28fa4b7f1987b5ce3bb672201b34e17a0cc919b908f2
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_app_aptest_2_file_then_succeeds
+        +test:
+            +title: test_pcl5_app_aptest_2
+            +guid:3475ea49-52ea-47f2-adba-a1d66faec95a
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_app_aptest_2_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('e5002a538d0fa1b3573f28fa4b7f1987b5ce3bb672201b34e17a0cc919b908f2')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_copern_pcl_macros_fonte_nc.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_copern_pcl_macros_fonte_nc.py
@@ -1,0 +1,67 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 copern using fonte_nc.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:fonte_nc.obj=9332b51f85d9ed1d91f74d23c0e51ee9ca9ab9b2ee26521a70384a3175431c60
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_copern_pcl_macros_fonte_nc_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_copern_pcl_macros_fonte_nc
+            +guid:5b541975-74b5-443f-9fc9-618e134a15fb
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_copern_pcl_macros_fonte_nc_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('9332b51f85d9ed1d91f74d23c0e51ee9ca9ab9b2ee26521a70384a3175431c60')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_font_vista8_camcal.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_font_vista8_camcal.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 font using camcal.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:camcal.obj=cef2c26028e26b7b9cb01cb3176215e36df7475555d6f8ab7ceaeec5b48ebd36
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_font_vista8_camcal_file_then_succeeds
+        +test:
+            +title: test_pcl5_font_vista8_camcal
+            +guid:bbe594d4-53d7-4ed9-91c5-c75ed21fc761
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_font_vista8_camcal_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('cef2c26028e26b7b9cb01cb3176215e36df7475555d6f8ab7ceaeec5b48ebd36')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_font_vista8_camcal_underline_res.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_font_vista8_camcal_underline_res.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 font using camcal_underline_res.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:camcal_underline_res.obj=b4995099a645973c3229dc7cbf87c6a2cbed6c1d6f6a1bd3f9f29356aa106087
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_font_vista8_camcal_underline_res_file_then_succeeds
+        +test:
+            +title: test_pcl5_font_vista8_camcal_underline_res
+            +guid:b9072e23-35ff-4afb-9e14-4613c5924a1b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_font_vista8_camcal_underline_res_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('b4995099a645973c3229dc7cbf87c6a2cbed6c1d6f6a1bd3f9f29356aa106087')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_font_vista8_symbolset_calibri.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_font_vista8_symbolset_calibri.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 font using Calibri.pcl
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:Calibri.pcl=9035740c42051cdd90e3f715eaf3581f0c714c9722f02142b42dd4aad3b8d501
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_font_vista8_symbolset_calibri_file_then_succeeds
+        +test:
+            +title: test_pcl5_font_vista8_symbolset_calibri
+            +guid:80ed66af-ab96-4def-9666-9e159abbc63d
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_font_vista8_symbolset_calibri_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('9035740c42051cdd90e3f715eaf3581f0c714c9722f02142b42dd4aad3b8d501')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_font_vista8_symbolset_cambria.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_font_vista8_symbolset_cambria.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 font using Cambria.pcl
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:Cambria.pcl=d64282aa399e6726a555bd0a9bffe974e21328aa014ff0d37e82c142b79ae521
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_font_vista8_symbolset_cambria_file_then_succeeds
+        +test:
+            +title: test_pcl5_font_vista8_symbolset_cambria
+            +guid:202e177d-8de0-4c2c-a742-3d806bf5afd1
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_font_vista8_symbolset_cambria_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('d64282aa399e6726a555bd0a9bffe974e21328aa014ff0d37e82c142b79ae521')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_df.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_df.py
@@ -1,0 +1,67 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using df.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:df.obj=2f3d67438dd745c5289cc0bb7666fef5d43b9ffe660a899c00e0d7a841aa3fab
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_cfgstat_df_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_hpgl_cfgstat_df
+            +guid:563d902c-39f8-4af9-aa6c-af78d7d78a57
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_cfgstat_df_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2f3d67438dd745c5289cc0bb7666fef5d43b9ffe660a899c00e0d7a841aa3fab')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_esc_e.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_esc_e.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using esc_e.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:esc_e.obj=d02fe9ae56b0fb21151df8050c91bed827391d82627c985d485609adbcc84f7f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_cfgstat_esc_e_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_cfgstat_esc_e
+            +guid:3ca2b731-05ff-4bde-bf79-57e614a11b1e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_cfgstat_esc_e_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('d02fe9ae56b0fb21151df8050c91bed827391d82627c985d485609adbcc84f7f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_ip.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_ip.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ip.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ip.obj=b0fd218eb9d0b75d0f5e065e394c4296214cb2d633d24a2078ce367a1aaeaaae
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_cfgstat_ip_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_cfgstat_ip
+            +guid:12b16239-7dac-4e51-a96e-c047ed955ba0
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_cfgstat_ip_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('b0fd218eb9d0b75d0f5e065e394c4296214cb2d633d24a2078ce367a1aaeaaae')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_ir.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_ir.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ir.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ir.obj=229f31ce7e9aed8a7d9ff19e5b7fe3c2b377859786c65abfe97ddb64629926d6
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_cfgstat_ir_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_cfgstat_ir
+            +guid:60b4b9ad-b7b6-466a-81a3-afea89b70e78
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_cfgstat_ir_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('229f31ce7e9aed8a7d9ff19e5b7fe3c2b377859786c65abfe97ddb64629926d6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_iw.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_iw.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using iw.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:iw.obj=6f8307c8767df01bdf694c3118d9549bf8f46729c411ffd9d46913a5d4ab36f6
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_cfgstat_iw_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_cfgstat_iw
+            +guid:2c98b202-91fe-4b0a-867d-f3bf8bf16975
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_cfgstat_iw_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('6f8307c8767df01bdf694c3118d9549bf8f46729c411ffd9d46913a5d4ab36f6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_pg.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_pg.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pg.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pg.obj=69546298d0012177f1d1584d8ccf07ec5ce5760657f3afeb3f6057d059e3bd80
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_cfgstat_pg_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_cfgstat_pg
+            +guid:cd81481b-960f-4ecc-87dc-7efcd5c0beef
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_cfgstat_pg_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('69546298d0012177f1d1584d8ccf07ec5ce5760657f3afeb3f6057d059e3bd80')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_ro.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_ro.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ro.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ro.obj=2691671f5708dce4d93cd5443e03320724d621f0c1fbb89755d0aed589857528
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_cfgstat_ro_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_cfgstat_ro
+            +guid:d3577120-c433-4334-ba7b-aae9c7e73bb5
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_cfgstat_ro_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2691671f5708dce4d93cd5443e03320724d621f0c1fbb89755d0aed589857528')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_rp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_rp.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using rp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:rp.obj=f82f08a4b4b32028a49eb501fef19d6b393d5a8ce961feeb0c66d1b788c03064
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_cfgstat_rp_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_cfgstat_rp
+            +guid:ad68f5cb-b7d1-4b76-a300-5ded29515ea8
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_cfgstat_rp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('f82f08a4b4b32028a49eb501fef19d6b393d5a8ce961feeb0c66d1b788c03064')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_sc.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_cfgstat_sc.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using sc.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:sc.obj=65ac845e33bcc793482b5e99b673aef0850a7e245d7727917321bfd67f99908f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_cfgstat_sc_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_cfgstat_sc
+            +guid:193f7455-6e84-4892-892f-86acefeab4df
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_cfgstat_sc_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('65ac845e33bcc793482b5e99b673aef0850a7e245d7727917321bfd67f99908f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_ad.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_ad.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ad.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ad.obj=5c5898f35aa6b04d8038f56c0e4d31d7914706288001f565b4b85026d3bdeddf
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_ad_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_ad
+            +guid:5ec30b9f-aa67-4118-9ae4-f14f25092669
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_ad_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('5c5898f35aa6b04d8038f56c0e4d31d7914706288001f565b4b85026d3bdeddf')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_cf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_cf.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using cf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:cf.obj=e141712a17bf1a30b939466567c976e63655bf8f00fb2629df17071510c2e309
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_cf_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_cf
+            +guid:beab19bf-2c83-4b0b-8ed4-336510194449
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_cf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('e141712a17bf1a30b939466567c976e63655bf8f00fb2629df17071510c2e309')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_cp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_cp.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using cp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:cp.obj=a60e4a31e61e250a059b382ded3fdfe7c332061ae240faf562fa80c9131efed5
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_cp_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_cp
+            +guid:2a36ac78-fa8d-4ada-8f61-24f105ad2e8d
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_cp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('a60e4a31e61e250a059b382ded3fdfe7c332061ae240faf562fa80c9131efed5')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_di.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_di.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using di.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:di.obj=64eafdc3c162a7f2a53b3e43e129b0a3d42e186605d4d91526beb03c61709be7
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_di_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_di
+            +guid:7aff8b1f-8693-4faa-803f-a8b694d3ebb9
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_di_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('64eafdc3c162a7f2a53b3e43e129b0a3d42e186605d4d91526beb03c61709be7')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_dr.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_dr.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using dr.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:dr.obj=c04b499cf2e91f973908e9f693eca32118ddc7c5b4acb1bb0a2b33a1f83d5b84
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_dr_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_dr
+            +guid:ed897ce6-0870-4ff1-ae91-555742072dc9
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_dr_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('c04b499cf2e91f973908e9f693eca32118ddc7c5b4acb1bb0a2b33a1f83d5b84')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_dt.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_dt.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using dt.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:dt.obj=ec4e7ce6336a0387ba022f655d168c115b3f605f7c28e1693e0547c0b16308d8
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_dt_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_dt
+            +guid:8a3a092e-8c9e-4c84-9474-496dfee8ac75
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_dt_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('ec4e7ce6336a0387ba022f655d168c115b3f605f7c28e1693e0547c0b16308d8')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_dv.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_dv.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using dv.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:dv.obj=4e3e54ac90a45a1ddab95979ec0268bcd2af698b06473a5c1642e3295526a022
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_dv_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_dv
+            +guid:80cd2567-7ea3-4e7e-807f-28e669aec22c
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_dv_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('4e3e54ac90a45a1ddab95979ec0268bcd2af698b06473a5c1642e3295526a022')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_fi.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_fi.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using fi.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:fi.obj=39de0ab3106ac7c523c0a0f38ba697a8721dd44931cae81471830638d0f8e616
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_fi_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_fi
+            +guid:1f4fea3c-80a8-421b-a6ce-a998a1076580
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_fi_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('39de0ab3106ac7c523c0a0f38ba697a8721dd44931cae81471830638d0f8e616')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_fn.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_fn.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using fn.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:fn.obj=7275ce3dfae332bdf0e03b5f272117abde8a1c49d9e5121aec4fcad4766e8acb
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_fn_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_fn
+            +guid:3ad6556f-83c4-4849-a322-4d1ea7ec31a8
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_fn_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('7275ce3dfae332bdf0e03b5f272117abde8a1c49d9e5121aec4fcad4766e8acb')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_lb.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_lb.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using lb.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:lb.obj=5f683b214c63be3ba0639d86084760366156174019fbcdb03bcd72899ab27f2c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_lb_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_lb
+            +guid:fc0ade2d-09f0-4b7b-9451-02a6fbb821c5
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_lb_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('5f683b214c63be3ba0639d86084760366156174019fbcdb03bcd72899ab27f2c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_lm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_lm.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using lm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:lm.obj=7ecc33a4122dcff25b9d0580ab2c2a5beefe89c4a80f279f95c4ac760508cb0f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_lm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_lm
+            +guid:8fe0ad37-a086-44c9-8392-24355908899c
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_lm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('7ecc33a4122dcff25b9d0580ab2c2a5beefe89c4a80f279f95c4ac760508cb0f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_lo.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_lo.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using lo.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:lo.obj=92952ba1fd14404c362d68765ad71c44db12b922283aaa69b731098c753d4b6a
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_lo_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_lo
+            +guid:7eb93880-1ff7-48f1-acde-924688232ad5
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_lo_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('92952ba1fd14404c362d68765ad71c44db12b922283aaa69b731098c753d4b6a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_sa.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_sa.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using sa.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:sa.obj=2ad5744b2f71d3c190bf9967a51e82b7a1aa99a56472d478f8f413ae667aca9e
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_sa_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_sa
+            +guid:b89b8409-eecb-4959-bc09-6a4485064287
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_sa_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2ad5744b2f71d3c190bf9967a51e82b7a1aa99a56472d478f8f413ae667aca9e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_sb.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_sb.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using sb.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:sb.obj=74595842fbad2577fc7bbe153040128bb9e2edc57e781b2b11e12ccafe259a46
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_sb_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_sb
+            +guid:844a3dbf-acc6-49dd-af9a-6211099e084f
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_sb_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('74595842fbad2577fc7bbe153040128bb9e2edc57e781b2b11e12ccafe259a46')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_si.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_si.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using si.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:si.obj=95a95fe40b073dda0b9ec2f20b2cbbf551072e91fa0d665f3f9bf3d0cc6d41de
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_si_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_si
+            +guid:14ee9ff3-5e34-4ddd-9c78-3ba74db98564
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_si_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('95a95fe40b073dda0b9ec2f20b2cbbf551072e91fa0d665f3f9bf3d0cc6d41de')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_sl.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_sl.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using sl.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:sl.obj=8c80b332b15c890ca521e6aecf21882a3aaeb41819f1c2efc16e3ffd58fd8554
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_sl_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_sl
+            +guid:6ba08a23-a8e3-49c4-95a8-313e6321f687
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_sl_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('8c80b332b15c890ca521e6aecf21882a3aaeb41819f1c2efc16e3ffd58fd8554')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_sl2.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_sl2.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using sl2.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:sl2.obj=5ce6f7253c5e1f629b081247186545f236a1ae163be792b7953caee68c012961
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_sl2_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_sl2
+            +guid:8009c4ba-2df5-4a4f-98e4-f8044294ed8b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_sl2_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('5ce6f7253c5e1f629b081247186545f236a1ae163be792b7953caee68c012961')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_ss.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_ss.py
@@ -1,0 +1,69 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ss.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ss.obj=68ae958c9baf7ee0b2771468d256f96e064737752f527fa1fe487575198dca79
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_ss_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_ss
+            +guid:58859148-39a8-479f-bb73-ca84b050a3a4
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+    
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_ss_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('68ae958c9baf7ee0b2771468d256f96e064737752f527fa1fe487575198dca79')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_td.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_td.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using td.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:td.obj=aeea9a6db2680ef0553bb71c2e0d5ef3a999936d93a28973a403553ddd393e5a
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_td_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_td
+            +guid:221f7cd5-2c5f-4b07-b83f-51f8815cac3e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_td_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('aeea9a6db2680ef0553bb71c2e0d5ef3a999936d93a28973a403553ddd393e5a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_japgoth.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_japgoth.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using japgoth.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:japgoth.obj=3c7a079523629524b84f21e5afe0754173aa5fe9072f7d275f2e8bff103ef7c1
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_japgoth_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_japgoth
+            +guid:3ac71ddc-c137-4231-a919-e8a9e422dab5
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_japgoth_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('3c7a079523629524b84f21e5afe0754173aa5fe9072f7d275f2e8bff103ef7c1')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_jpmin.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_jpmin.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using jpmin.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jpmin.obj=2f6cc3334ed38e06ef800d3438213e1e0ebc8a2525767d7969398b2d68101b0c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_jpmin_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_jpmin
+            +guid:880dab9a-d9dc-430e-be2a-4d2abb9fbab4
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_jpmin_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2f6cc3334ed38e06ef800d3438213e1e0ebc8a2525767d7969398b2d68101b0c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_jppgoth.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_jppgoth.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using jppgoth.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jppgoth.obj=0ef7318db51bab26f95f69706aa4e90797269b7c83950d3c37bc35f902aab54d
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_jppgoth_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_jppgoth
+            +guid:ed03c147-9488-4e31-b937-461196ebbd01
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_jppgoth_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('0ef7318db51bab26f95f69706aa4e90797269b7c83950d3c37bc35f902aab54d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_jppmin.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_jppmin.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using jppmin.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jppmin.obj=a3798d00ac083710c56a45e81e0ee6ec32b695ff912e3c59638c99952e2680f0
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_jppmin_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_jppmin
+            +guid:138913cc-a9d4-44db-8491-742327a58910
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_jppmin_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('a3798d00ac083710c56a45e81e0ee6ec32b695ff912e3c59638c99952e2680f0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_jppminv.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_jppminv.py
@@ -1,0 +1,69 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using jppminv.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jppminv.obj=e6a0ce94f5a0a1b017b411ed93e13f598c76e6c66cad16ebca1a9cba365684fc
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_jppminv_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_jppminv
+            +guid:d21c8632-e639-4259-9180-eeac889e3360
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_jppminv_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('e6a0ce94f5a0a1b017b411ed93e13f598c76e6c66cad16ebca1a9cba365684fc')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knbcf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knbcf.py
@@ -1,0 +1,69 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using knbcf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:knbcf.obj=aeac5d8b31c011846a1f05f2e45813cb2640100a484a38852bebf583a7e445a0
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knbcf_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_knbcf
+            +guid:12f555a9-0752-47f0-ab9e-e76af6bec468
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+        +overrides:
+            +Enterprise:
+                +is_manual:False
+                +timeout:600
+                +test:
+                    +dut:
+                        +type:Emulator
+
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knbcf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('aeac5d8b31c011846a1f05f2e45813cb2640100a484a38852bebf583a7e445a0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knbcp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knbcp.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using knbcp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:knbcp.obj=e8da58c4af6179db794196078d2a8ebe4f2a61f5753eea7581739c5e31ff24a0
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knbcp_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_knbcp
+            +guid:5cd2de56-fc81-4a87-9648-28acf02079cc
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knbcp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('e8da58c4af6179db794196078d2a8ebe4f2a61f5753eea7581739c5e31ff24a0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_kndcf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_kndcf.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using kndcf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kndcf.obj=4b4e0fb96a5c17de7c14a9031f17efed74ab7ceebafef0975f57fc61d2e855b6
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_kndcf_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_kndcf
+            +guid:c1f5a2b6-5ee7-455b-91b4-201dc2278d98
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_kndcf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('4b4e0fb96a5c17de7c14a9031f17efed74ab7ceebafef0975f57fc61d2e855b6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_kndcp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_kndcp.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using kndcp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kndcp.obj=f5fec4e395dd632ab0ba36441349d31d0e6fe44a4663f19f7886778cfe0375b7
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_kndcp_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_kndcp
+            +guid:628a4f74-1288-443b-96e4-d70190b0dc16
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_kndcp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('f5fec4e395dd632ab0ba36441349d31d0e6fe44a4663f19f7886778cfe0375b7')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_kngcf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_kngcf.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using kngcf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kngcf.obj=c69e21b19db6a79c393e92aada385ccf12b287a6f597b84c244749d275f887ff
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_kngcf_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_kngcf
+            +guid:83a0d973-11db-459a-bc1e-84ac89959134
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_kngcf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('c69e21b19db6a79c393e92aada385ccf12b287a6f597b84c244749d275f887ff')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_kngcpv.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_kngcpv.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using kngcpv.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kngcpv.obj=035426db4aa01d143397b4305b0a2c12b80ed34f479e6c760ac4a80998252840
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_kngcpv_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_kngcpv
+            +guid:dfb77c44-63d3-4b25-b906-26e0687d19ab
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_kngcpv_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('035426db4aa01d143397b4305b0a2c12b80ed34f479e6c760ac4a80998252840')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_kngscf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_kngscf.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using kngscf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kngscf.obj=9d020a6da2e0bbdfee25f7ef9ee5fd4d5ccde25991e0f9fa24f9b3556018745e
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_kngscf_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_kngscf
+            +guid:4a215f4b-563d-4760-8487-bef43435b548
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_kngscf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('9d020a6da2e0bbdfee25f7ef9ee5fd4d5ccde25991e0f9fa24f9b3556018745e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_kngscp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_kngscp.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using kngscp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kngscp.obj=7cdc9243bb636a76a2b10a662d06b181c07fd3bcbc752f38de8fb43f66731751
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_kngscp_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_kngscp
+            +guid:fba3200a-3c11-4295-b5b0-ae7ceda012b4
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_kngscp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('7cdc9243bb636a76a2b10a662d06b181c07fd3bcbc752f38de8fb43f66731751')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhbf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhbf.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using knhbf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:knhbf.obj=2c177936a83a5192d07f910154949d1829c41df53222f77cf1c60f650646ba57
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhbf_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_knhbf
+            +guid:8451b9cc-578d-42a0-9f87-9f8e7ac15599
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhbf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2c177936a83a5192d07f910154949d1829c41df53222f77cf1c60f650646ba57')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhbp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhbp.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using knhbp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:knhbp.obj=8b2a3d95e8279e9ec13675147616069e6856fdd5c1483042725d708facad9c5b
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhbp_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_knhbp
+            +guid:fd7ce265-abb9-4b22-806c-009ee554a491
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhbp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('8b2a3d95e8279e9ec13675147616069e6856fdd5c1483042725d708facad9c5b')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhdf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhdf.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using knhdf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:knhdf.obj=807994a367cb74392914464659a77862bea7afecf9efa9690579cbb6801a1b67
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhdf_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_knhdf
+            +guid:034379fc-9eaa-4a72-aff4-2e7c6da93f35
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhdf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('807994a367cb74392914464659a77862bea7afecf9efa9690579cbb6801a1b67')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhdp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhdp.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using knhdp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:knhdp.obj=dd5718d66bcb4f66f5d6dfad7aa97f8e89eecec88d9950ae32a5060b94cd4e2f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhdp_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_knhdp
+            +guid:6e60ef51-13b3-40a3-9bd1-f60114807d26
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhdp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('dd5718d66bcb4f66f5d6dfad7aa97f8e89eecec88d9950ae32a5060b94cd4e2f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhgf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhgf.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using knhgf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:knhgf.obj=b1c35b2afb989f62c202ec3c2887b4a87182deb610f5147b76ab5b33d57ccf33
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhgf_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_knhgf
+            +guid:0e6ec363-224d-4779-96d3-adb8614b7c52
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhgf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('b1c35b2afb989f62c202ec3c2887b4a87182deb610f5147b76ab5b33d57ccf33')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhgp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhgp.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using knhgp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:720
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:knhgp.obj=14312bb383762b5699ec654a625a18d36e0dfa7fc638bcad968f8939f86c4eca
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhgp_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_knhgp
+            +guid:0168e7ee-c8e7-4997-bf92-7449bfc9a2d7
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhgp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('14312bb383762b5699ec654a625a18d36e0dfa7fc638bcad968f8939f86c4eca')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhgpv.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhgpv.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using knhgpv.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:knhgpv.obj=1f92baeb801ac2448e8e4b9491d67288461596f9e98101e9439644327dcce9c2
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhgpv_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_knhgpv
+            +guid:a8d15073-b435-47d7-823c-45ba88b84c85
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhgpv_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('1f92baeb801ac2448e8e4b9491d67288461596f9e98101e9439644327dcce9c2')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhgsf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhgsf.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using knhgsf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:knhgsf.obj=8289934308ad3d77dd0a2aed5d2d2f784e26dddfebb8207ff1c94dd006daba02
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhgsf_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_knhgsf
+            +guid:ca592c51-31d7-4b68-afd3-aa73fa470ee2
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhgsf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('8289934308ad3d77dd0a2aed5d2d2f784e26dddfebb8207ff1c94dd006daba02')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhgsp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_knhgsp.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using knhgsp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:knhgsp.obj=9931406968b6ebb51b16c241aeff64fce1b36bfcd4d226cc9947cf5df9c7b90a
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhgsp_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_knhgsp
+            +guid:14076bf2-8777-426a-9990-9235ec0dbb82
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_knhgsp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('9931406968b6ebb51b16c241aeff64fce1b36bfcd4d226cc9947cf5df9c7b90a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_schsf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_schsf.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using schsf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:schsf.obj=ffead46d2cac62b40d7b3d729b19b76e6749f78eb6924b24667c972ea2cd841e
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_schsf_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_schsf
+            +guid:b6e4b7a8-b079-4791-a62f-6ffea75d7556
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_schsf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('ffead46d2cac62b40d7b3d729b19b76e6749f78eb6924b24667c972ea2cd841e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_schsh.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_schsh.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using schsh.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:schsh.obj=62f1b7db75ec72753d3a67dd9b044b45afe1ae59eb372c57e7571f301f66983f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_schsh_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_schsh
+            +guid:53aa0706-c761-4c75-b934-0e46e1480880
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_schsh_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('62f1b7db75ec72753d3a67dd9b044b45afe1ae59eb372c57e7571f301f66983f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_schsk.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_schsk.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using schsk.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:schsk.obj=dd16356c6887e4a80d8fd9178d08fb1e86efb8fa05fb9a11d031af8ac6d1c2fa
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_schsk_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_schsk
+            +guid:c3808e15-d67d-4d6f-8286-672c713f0ce9
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_schsk_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('dd16356c6887e4a80d8fd9178d08fb1e86efb8fa05fb9a11d031af8ac6d1c2fa')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_schss.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_schss.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using schss.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:schss.obj=fbb572d2fa7d28674b67ed963747bc92c0978adf4fb788fbff902a45b7927fed
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_schss_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_schss
+            +guid:7b44eaab-f89f-4a45-8757-ea5f443781ec
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_schss_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('fbb572d2fa7d28674b67ed963747bc92c0978adf4fb788fbff902a45b7927fed')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_tchdkm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_tchdkm.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using tchdkm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tchdkm.obj=0b3af0b92aae0d5f18674b67eb8c87e324a46dce57bb6f155bb0ca53c9c76310
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_tchdkm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_tchdkm
+            +guid:e37a0301-49b4-4b00-b675-3128ac095525
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_tchdkm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('0b3af0b92aae0d5f18674b67eb8c87e324a46dce57bb6f155bb0ca53c9c76310')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_tchdml.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_tchdml.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using tchdml.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tchdml.obj=1519f9c8f62a20fed5914c635276044dbfb6ecddd345c62c444582a947c600d3
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_tchdml_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_tchdml
+            +guid:5a976258-96f5-4244-9442-d3ece4717c38
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_tchdml_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('1519f9c8f62a20fed5914c635276044dbfb6ecddd345c62c444582a947c600d3')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_tchpml.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_tchpml.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using tchpml.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tchpml.obj=5ac4abe2f5d7ecab3ea5fb25428b15c1a172bcf04c8f5951596818706c320deb
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_tchpml_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_tchpml
+            +guid:29c9804e-66b6-45af-8abd-cacd126f1864
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_tchpml_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('5ac4abe2f5d7ecab3ea5fb25428b15c1a172bcf04c8f5951596818706c320deb')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_tchpmlv.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_2bytetypeface_tchpmlv.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using tchpmlv.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tchpmlv.obj=c802eb762eb81f0a83baf16168e90f53257d6444c63c4a17b7ee76dd69767e05
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_2bytetypeface_tchpmlv_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_2bytetypeface_tchpmlv
+            +guid:4842dfd9-f7bd-4277-b186-bc88f427e8cd
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_2bytetypeface_tchpmlv_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('c802eb762eb81f0a83baf16168e90f53257d6444c63c4a17b7ee76dd69767e05')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_ctmlm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_ctmlm.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ctmlm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ctmlm.obj=fb376142e14b31c3384cd94fb53029ffe75042c60c94c70ed14428be74459cf6
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_ctmlm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_ctmlm
+            +guid:30f6ec81-59e5-4a86-ada1-ee63f7e76ef8
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_ctmlm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('fb376142e14b31c3384cd94fb53029ffe75042c60c94c70ed14428be74459cf6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_fi_tt.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_fi_tt.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using fi_tt.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:720
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:fi_tt.obj=a5943dfde1f19648bfdbd0277df1836fd7316e47d6cf342535fe6c2622a24898
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_fi_tt_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_fi_tt
+            +guid:5cb1c3a0-056b-49de-aec0-ef2be3558175
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_fi_tt_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('a5943dfde1f19648bfdbd0277df1836fd7316e47d6cf342535fe6c2622a24898')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_fn_tt.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_fn_tt.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using fn_tt.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:fn_tt.obj=f80e2144bb9de53f471f6442502810e6bfc240728f53e993382de8141e6a2b35
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_fn_tt_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_fn_tt
+            +guid:f76f8e3a-c0f6-4901-8244-b6eb9a58da19
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_fn_tt_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('f80e2144bb9de53f471f6442502810e6bfc240728f53e993382de8141e6a2b35')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_sb_tt.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_sb_tt.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using sb_tt.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:sb_tt.obj=248b08ec04f46199eaeaae5559792fbbf04c6bf8eb4044f09db7bf0a6608b318
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_sb_tt_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_sb_tt
+            +guid:82f7d832-0872-407b-9d64-b37357bb5b12
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_sb_tt_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('248b08ec04f46199eaeaae5559792fbbf04c6bf8eb4044f09db7bf0a6608b318')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_sd_tt.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_sd_tt.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using sd_tt.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:sd_tt.obj=5f0fd333cc8cce1ea8c1e027592844632d9b01de6652b7cfde8f0b9e13b350f4
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_sd_tt_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_sd_tt
+            +guid:5ba96be4-da71-4eca-8976-1b8c394d697c
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_sd_tt_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('5f0fd333cc8cce1ea8c1e027592844632d9b01de6652b7cfde8f0b9e13b350f4')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_sr2_tt.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_sr2_tt.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using sr2_tt.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:720
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:sr2_tt.obj=2bd416c376b354ff7d3f2ee38d25dd221fe7d15427481a0546b33266823e0dbb
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_sr2_tt_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_sr2_tt
+            +guid:c37817d7-2f26-4c6f-bf9f-b4e13c87a6d7
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_sr2_tt_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2bd416c376b354ff7d3f2ee38d25dd221fe7d15427481a0546b33266823e0dbb')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_ss_tt.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_ss_tt.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ss_tt.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ss_tt.obj=a99c394a9335dd61c6401a1eeb75f94893e13f1cc127b1c47276e04b720e26fb
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_ss_tt_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_ss_tt
+            +guid:de722d5d-7ca1-4418-b3dd-ce1eb62e529f
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_ss_tt_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('a99c394a9335dd61c6401a1eeb75f94893e13f1cc127b1c47276e04b720e26fb')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_td_tt.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_char_tt_td_tt.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using td_tt.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:td_tt.obj=861faef8ebfda970a242f29d4c1224b1cc20c15d4e85cd99a4d70ec80f04e679
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_char_tt_td_tt_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_char_tt_td_tt
+            +guid:9e66d39a-45b1-4aa6-a0c4-1534073002fd
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_char_tt_td_tt_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('861faef8ebfda970a242f29d4c1224b1cc20c15d4e85cd99a4d70ec80f04e679')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_ac.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_ac.py
@@ -1,0 +1,67 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ac.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:ac.obj=90891762429c5c35f0f31435ed150e56cb6c1b137e176ff2ca4a3bd9aae9ab41
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_ac_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_hpgl_lfatt_ac
+            +guid:e6937d94-91c4-4a68-94fb-70500a8c1e1a
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_ac_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('90891762429c5c35f0f31435ed150e56cb6c1b137e176ff2ca4a3bd9aae9ab41')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_ft.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_ft.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ft.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ft.obj=96e8e1e3032a89474e49374d059eab93ea458d2da8da0e8ad9263cd28f3ed8ee
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_ft_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_lfatt_ft
+            +guid:d7ebe2e0-2c69-4916-aa75-dbb66a26f928
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_ft_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('96e8e1e3032a89474e49374d059eab93ea458d2da8da0e8ad9263cd28f3ed8ee')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_ft2.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_ft2.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ft2.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ft2.obj=b0d4147e3dde1d24d5020aece1d3e0e71d43bc8e6b1174fb98c727fc5e0da6d8
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_ft2_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_lfatt_ft2
+            +guid:65ba0cb1-b868-4a9e-9ffd-f1796c6de513
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_ft2_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('b0d4147e3dde1d24d5020aece1d3e0e71d43bc8e6b1174fb98c727fc5e0da6d8')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_la.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_la.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using la.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:la.obj=f5eb8d265978552e0815d43b6f5b647698cfc02d0dc6a53b4e5c16711e454452
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_la_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_lfatt_la
+            +guid:9f9a6d76-1674-49a3-b78a-081983267a6d
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_la_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('f5eb8d265978552e0815d43b6f5b647698cfc02d0dc6a53b4e5c16711e454452')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_lt.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_lt.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using lt.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:lt.obj=c60377868accb74df9119bcde7ced3adf194b90231ef694b2605b750c9246574
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_lt_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_lfatt_lt
+            +guid:e2e80295-d036-48d5-a8dc-78d52647fd0a
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_lt_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('c60377868accb74df9119bcde7ced3adf194b90231ef694b2605b750c9246574')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_pw.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_pw.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pw.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pw.obj=b42cb8bab2b2452cb1e5310ae4a4890a7714d93b59303bc6b76e190fef76a4b5
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_pw_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_lfatt_pw
+            +guid:a8a71940-19be-4001-8c2d-d0ba90263462
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_pw_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('b42cb8bab2b2452cb1e5310ae4a4890a7714d93b59303bc6b76e190fef76a4b5')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_rf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_rf.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using rf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:rf.obj=0489e2221e87404fdeb83d44efcf2b6d1675d9c192f6c9091f319d13392b48e6
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_rf_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_lfatt_rf
+            +guid:a7b26e57-e1a2-4305-a651-7c6a3be5a88f
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_rf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('0489e2221e87404fdeb83d44efcf2b6d1675d9c192f6c9091f319d13392b48e6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_sm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_sm.py
@@ -1,0 +1,67 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using sm.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:sm.obj=1889df4abb60269c1ade95730cd64a6cdc6c3f3814ddc1e0c5be0660aeddf128
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_sm_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_hpgl_lfatt_sm
+            +guid:d046519c-a6d3-4aa0-89cf-4b60a84ab7d1
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_sm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('1889df4abb60269c1ade95730cd64a6cdc6c3f3814ddc1e0c5be0660aeddf128')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_sv.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_sv.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using sv.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:sv.obj=fd18686dc36aa3f1fc807f5eacf0ed57288b80eb9dd780296ab52b2b0862f2a4
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_sv_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_lfatt_sv
+            +guid:50ab706f-a8cf-4636-9e71-3b3089f68b97
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_sv_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('fd18686dc36aa3f1fc807f5eacf0ed57288b80eb9dd780296ab52b2b0862f2a4')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_tt_ft.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_tt_ft.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ft_tt.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ft_tt.obj=b0ce60a72e48f7b7dd2ae893a0f5b1979a47120d550fee2e916d01b68cf5bd11
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_tt_ft_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_lfatt_tt_ft
+            +guid:701641b4-a356-49df-bd98-baa2ab49d8aa
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_tt_ft_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('b0ce60a72e48f7b7dd2ae893a0f5b1979a47120d550fee2e916d01b68cf5bd11')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_tt_pw_tt.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_tt_pw_tt.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pw_tt.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pw_tt.obj=c1bc483810f7894e6b8fcbea64be2c41176f22c672e5ba5165df8bb1671f8272
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_tt_pw_tt_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_lfatt_tt_pw_tt
+            +guid:2f7c99b2-16f1-4e4a-a89d-e9512877383b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_tt_pw_tt_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('c1bc483810f7894e6b8fcbea64be2c41176f22c672e5ba5165df8bb1671f8272')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_tt_rf_tt.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_tt_rf_tt.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using rf_tt.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:rf_tt.obj=9f8973a1a458d4ae46f4d9f67e9c9f7d32131ef9ec4d41e52e91a195471c02b3
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_tt_rf_tt_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_lfatt_tt_rf_tt
+            +guid:d15c2dc5-121d-44f1-9fbb-68f8cdd2a3a4
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_tt_rf_tt_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('9f8973a1a458d4ae46f4d9f67e9c9f7d32131ef9ec4d41e52e91a195471c02b3')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_ul2.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_ul2.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ul2.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ul2.obj=54af8e9f5aa60bdc8095949ae04173813dc4779db00c5be8dedcc1a9c787aa0e
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_ul2_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_lfatt_ul2
+            +guid:79dbc993-309b-4c4f-96a2-287493ea25d9
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_ul2_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('54af8e9f5aa60bdc8095949ae04173813dc4779db00c5be8dedcc1a9c787aa0e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_wu.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_wu.py
@@ -1,0 +1,60 @@
+
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using wu.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:wu.obj=87c0f050c4d7d1c3543a023341a7d5feac3817ac72bb094f58f600f964616afc
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_wu_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_lfatt_wu
+            +guid:68edacf1-3733-4b55-965d-010359aeef28
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_wu_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('87c0f050c4d7d1c3543a023341a7d5feac3817ac72bb094f58f600f964616afc')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_wu2.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_lfatt_wu2.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using wu2.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:720
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:wu2.obj=81991e979dd883447bd6d403c9bb3ceb962ac2d35f9240e449ab7612ce6e3777
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_lfatt_wu2_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_lfatt_wu2
+            +guid:31912c95-017d-49eb-a1e6-46f5ef6478b4
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_lfatt_wu2_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('81991e979dd883447bd6d403c9bb3ceb962ac2d35f9240e449ab7612ce6e3777')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ea.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ea.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ea.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ea.obj=7351d5429aac7a2e04fb9487c4b3b374d80ab56fee1c4f9e9d083d43ceffe494
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_ea_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_ea
+            +guid:7d76c5f5-8655-43dd-82a7-89014f40405c
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_ea_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('7351d5429aac7a2e04fb9487c4b3b374d80ab56fee1c4f9e9d083d43ceffe494')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ea_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ea_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ea_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ea_igm.obj=aefd4f04d7e36dc00164dbe7b49ffdeb55f6805ef59f52bfa8ce33b5d3793e43
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_ea_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_ea_igm
+            +guid:6917b84d-3157-448a-8085-1c8a56ed4e5b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_ea_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('aefd4f04d7e36dc00164dbe7b49ffdeb55f6805ef59f52bfa8ce33b5d3793e43')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ep.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ep.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ep.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ep.obj=4ef29805747d12a10c99fe242c0a9ec5df45636dec15151742f219ccebc61815
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_ep_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_ep
+            +guid:3b165a6e-14e0-4e2f-afe6-6f14c49f772e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_ep_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('4ef29805747d12a10c99fe242c0a9ec5df45636dec15151742f219ccebc61815')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ep_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ep_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ep_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ep_igm.obj=88b7b65eeb303bc2d067fca32ff44b9355ec46001f0be0b8a3ab07b82187b794
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_ep_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_ep_igm
+            +guid:725bb042-0bdb-4ffb-97d5-39b5c8b8858a
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_ep_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('88b7b65eeb303bc2d067fca32ff44b9355ec46001f0be0b8a3ab07b82187b794')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_er.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_er.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using er.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:er.obj=bb97d8dce896020cf63874d74f408b7ea8dd3f56ceb8d88bda75775152761895
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_er_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_er
+            +guid:a93d28ca-3c1f-41c8-b3a7-5151e97920dc
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_er_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('bb97d8dce896020cf63874d74f408b7ea8dd3f56ceb8d88bda75775152761895')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_er_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_er_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using er_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:er_igm.obj=36ce32908a409ab4b6e1c1c786e67424e1eeed9399c0e60ae3d23da56dca5233
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_er_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_er_igm
+            +guid:23385ec8-dec0-40d4-ab80-5f7754cea161
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_er_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('36ce32908a409ab4b6e1c1c786e67424e1eeed9399c0e60ae3d23da56dca5233')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ew.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ew.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ew.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ew.obj=f5da7bea071d9bff3361f6cf49e091522e61602eeeb06900ec851b47e3b3e583
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_ew_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_ew
+            +guid:851f59c8-07fb-4715-a20b-5fb4e01390c9
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_ew_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('f5da7bea071d9bff3361f6cf49e091522e61602eeeb06900ec851b47e3b3e583')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ew_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ew_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ew_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ew_igm.obj=18d4dac329563628844f1503bd938c8988f346e65624334a0cd5809052a6df3c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_ew_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_ew_igm
+            +guid:1365944b-8d63-4ace-a6cd-7b57f90d4c64
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_ew_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('18d4dac329563628844f1503bd938c8988f346e65624334a0cd5809052a6df3c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_fp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_fp.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using fp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:fp.obj=64814422af13d76a94676ac7c1cc33830655c3bcc84a85b450827f88eca56760
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_fp_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_fp
+            +guid:938a2392-16ab-471b-bb00-d521b730fcc2
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_fp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('64814422af13d76a94676ac7c1cc33830655c3bcc84a85b450827f88eca56760')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_fp_comb_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_fp_comb_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using fp_comb_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:fp_comb_igm.obj=8f74b6379c5624297dd48f39f53b989e50485aee557c19fbc72801ebf82ad58c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_fp_comb_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_fp_comb_igm
+            +guid:a65f5b26-8ed4-4584-b412-1135ffe91656
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_fp_comb_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('8f74b6379c5624297dd48f39f53b989e50485aee557c19fbc72801ebf82ad58c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_fp_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_fp_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using fp_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:fp_igm.obj=c4504bdf498e6ea701be99dfc15f8437153490599d57e600bb27d5a297b645dc
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_fp_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_fp_igm
+            +guid:4c9dc74c-f284-4c14-a62b-ecc7b150b5d5
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_fp_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('c4504bdf498e6ea701be99dfc15f8437153490599d57e600bb27d5a297b645dc')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_fp_nzw.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_fp_nzw.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using fp_nzw.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:fp_nzw.obj=b87a4606e77bda07e593bc34588e722a23ad78868b378796489204dc426a152f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_fp_nzw_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_fp_nzw
+            +guid:b1b542d8-1d75-4f0b-81a1-98bbf567de1f
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_fp_nzw_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('b87a4606e77bda07e593bc34588e722a23ad78868b378796489204dc426a152f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_pm2_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_pm2_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pm2_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pm2_igm.obj=fa68643ca10bc3edc453b95d0f2d560335b351fa36ef26fd258ac21854ab7e87
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_pm2_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_pm2_igm
+            +guid:32ec5b4d-7e65-4cce-8cb8-878d05758bef
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_pm2_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('fa68643ca10bc3edc453b95d0f2d560335b351fa36ef26fd258ac21854ab7e87')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_pm_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_pm_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pm_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pm_igm.obj=aef1f37f4f39331731ba6c294403201e4ee7672c07934709fdb42af039f185e0
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_pm_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_pm_igm
+            +guid:9cba6536-7667-48a3-b2f9-70fafe469bd3
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_pm_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('aef1f37f4f39331731ba6c294403201e4ee7672c07934709fdb42af039f185e0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ra.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ra.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ra.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ra.obj=41d853ea0e97c85c2f3b6c5f1d97678f7a3070a06543578102a97916a3a044ed
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_ra_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_ra
+            +guid:6a4f985b-a0a9-4592-9df6-6be07318fea5
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_ra_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('41d853ea0e97c85c2f3b6c5f1d97678f7a3070a06543578102a97916a3a044ed')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ra_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_ra_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ra_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ra_igm.obj=8cd668fe86241415fc29e62e03dfcecb0233834ad66306bbd18c507e9a9c885a
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_ra_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_ra_igm
+            +guid:29f6ee8c-d193-491e-8ff8-f62d1f8f7e16
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_ra_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('8cd668fe86241415fc29e62e03dfcecb0233834ad66306bbd18c507e9a9c885a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_rq_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_rq_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using rq_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:rq_igm.obj=c3ceab48fd2651ab6e1e27a53b29ca5e5a0325dcc5fc3228febd2cb82dc9b893
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_rq_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_rq_igm
+            +guid:77406747-85cf-4174-a46c-31aa41dc4a84
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_rq_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('c3ceab48fd2651ab6e1e27a53b29ca5e5a0325dcc5fc3228febd2cb82dc9b893')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_rr.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_rr.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using rr.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:rr.obj=a431fbf12b18ecd2a22c11375954eb76417cbc5386342e365e21ddbfa750da7b
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_rr_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_rr
+            +guid:6c55a593-c141-4b85-814b-5c57ab0508b3
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_rr_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('a431fbf12b18ecd2a22c11375954eb76417cbc5386342e365e21ddbfa750da7b')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_rr_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_rr_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using rr_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:rr_igm.obj=365a1a90377241aa2a1c5636995c8c36a20c213762d76fa4960d688ec183b39f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_rr_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_rr_igm
+            +guid:dd959da7-0968-4aaa-bc35-39a42183b9be
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_rr_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('365a1a90377241aa2a1c5636995c8c36a20c213762d76fa4960d688ec183b39f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_wg.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_wg.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using wg.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:wg.obj=4a3c374acc522aaccf959c0a82b2ba5d6dd74e7ef4330b897059d4cceed64582
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_wg_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_wg
+            +guid:23b8b9b5-37ce-460c-bc66-561de468301a
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_wg_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('4a3c374acc522aaccf959c0a82b2ba5d6dd74e7ef4330b897059d4cceed64582')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_wg_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_polygon_wg_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using wg_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:720
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:wg_igm.obj=7d158518f870fe2348bcb3d2caacdf4b96929c2ef1384b6e35327f7a240d8f9c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_polygon_wg_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_polygon_wg_igm
+            +guid:ce56b064-5375-4afd-82c7-c34e152dea7d
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_polygon_wg_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('7d158518f870fe2348bcb3d2caacdf4b96929c2ef1384b6e35327f7a240d8f9c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_ar.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_ar.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ar.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ar.obj=bd038fbfa896fb6d84e1fc948124dcc5bccef6ca989b6e5328eb212129a1ee41
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_ar_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_ar
+            +guid:b0d9e986-8348-418f-b2eb-c626473affa9
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_ar_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('bd038fbfa896fb6d84e1fc948124dcc5bccef6ca989b6e5328eb212129a1ee41')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_ar_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_ar_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ar_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ar_igm.obj=747500ceea43af4cea4eecba2423e27cc61206f92895204e790dbc31c91d8807
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_ar_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_ar_igm
+            +guid:9072661d-4db4-44b0-a131-cb8a08843be6
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_ar_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('747500ceea43af4cea4eecba2423e27cc61206f92895204e790dbc31c91d8807')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_at_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_at_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using at_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:at_igm.obj=d1a74fef6e01bc0be2eeed8059f356bae3be3d5faac942898b4d4458eb93cb2a
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_at_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_at_igm
+            +guid:033b02cf-f185-4f2f-b050-0ba94ba8726b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_at_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('d1a74fef6e01bc0be2eeed8059f356bae3be3d5faac942898b4d4458eb93cb2a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_br_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_br_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using br_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:br_igm.obj=bcc25c09eaa8fac17c0f5ae54022e70e017cd03cef7f84e57ef7a440b35f3755
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_br_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_br_igm
+            +guid:bd7579f3-e5ca-48c5-9e06-d5a87bbf20cd
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_br_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('bcc25c09eaa8fac17c0f5ae54022e70e017cd03cef7f84e57ef7a440b35f3755')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_bz_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_bz_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using bz_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:720
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:bz_igm.obj=9da0ef52d0c958bac3804c758113178fa23c1987591d573bc9708fab47892833
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_bz_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_bz_igm
+            +guid:4d35e904-e59b-49ad-8613-fe6c2d227329
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_bz_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('9da0ef52d0c958bac3804c758113178fa23c1987591d573bc9708fab47892833')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_ci.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_ci.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using ci.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ci.obj=a302bec46e4b41662a86b393f4adc95a04ed9bd37ccf810a4f7c831e8daf0546
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_ci_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_ci
+            +guid:d050830e-b5c5-4a17-8f79-5b577763dc81
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_ci_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('a302bec46e4b41662a86b393f4adc95a04ed9bd37ccf810a4f7c831e8daf0546')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pa.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pa.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pa.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pa.obj=129950d89e0f499f6568795fac2f487febf794ee3899a4c51f15c87ff825749d
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_pa_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_pa
+            +guid:f362dbd4-3134-48e6-a98a-e70d1683107d
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_pa_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('129950d89e0f499f6568795fac2f487febf794ee3899a4c51f15c87ff825749d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pa_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pa_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pa_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pa_igm.obj=82885883bfe9b077072daa414f88fd00d0f73f9a5ae002501e3c211d7a2837e0
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_pa_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_pa_igm
+            +guid:21d75b7c-915c-4c37-941f-2cc608092c6b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_pa_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('82885883bfe9b077072daa414f88fd00d0f73f9a5ae002501e3c211d7a2837e0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pd.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pd.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pd.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pd.obj=480ccb94d5789edbaa26fb3702c953a7a8f0006fc49005e878ef1b411d2bcf63
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_pd_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_pd
+            +guid:f239250a-c3ab-4d87-ac11-f9b582a43ab2
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_pd_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('480ccb94d5789edbaa26fb3702c953a7a8f0006fc49005e878ef1b411d2bcf63')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pd_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pd_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pd_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pd_igm.obj=2747a936c4c1dd2ca35e983784ef5dba389eb5dc239867df3472e9e3f40555e1
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_pd_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_pd_igm
+            +guid:9293460d-f5ff-479a-9a60-f9497a1f51a3
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_pd_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2747a936c4c1dd2ca35e983784ef5dba389eb5dc239867df3472e9e3f40555e1')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pe.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pe.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pe.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pe.obj=1fba5081319e64ad34ae42dfe02819820a73be3068397c7eedc3323d66daf7f7
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_pe_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_pe
+            +guid:4f4be3ee-124e-4785-98cd-99a5f3034063
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_pe_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('1fba5081319e64ad34ae42dfe02819820a73be3068397c7eedc3323d66daf7f7')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pe_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pe_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pe_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:720
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pe_igm.obj=d3f208a5e63c16bee42361255054139882a3428e960ee036e8eccdb236f7ae23
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_pe_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_pe_igm
+            +guid:699362e6-4b17-470c-830b-cd2e99a95d4b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_pe_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('d3f208a5e63c16bee42361255054139882a3428e960ee036e8eccdb236f7ae23')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pr.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pr.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pr.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pr.obj=1e93cdc36d17ad332a1eca70f7a0b31a9aea85290855e989b80224b2afb19b0c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_pr_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_pr
+            +guid:5635cf80-326b-4447-952b-868b702d6583
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_pr_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('1e93cdc36d17ad332a1eca70f7a0b31a9aea85290855e989b80224b2afb19b0c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pr_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pr_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pr_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pr_igm.obj=83cd80795911ec882d434d48a8b8b407d08433d4912cb4a3aef8bdb99120d1b8
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_pr_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_pr_igm
+            +guid:66d12178-29f5-452f-aff6-79c257a5582b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_pr_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('83cd80795911ec882d434d48a8b8b407d08433d4912cb4a3aef8bdb99120d1b8')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pu.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pu.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pu.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pu.obj=ca31ae11adc0b4d72a331334d59e3a58c1858b8ff9e5b0643ad15c8e34905b91
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_pu_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_pu
+            +guid:9a84be74-9661-4ba2-b9fa-3324c159235e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_pu_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('ca31ae11adc0b4d72a331334d59e3a58c1858b8ff9e5b0643ad15c8e34905b91')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pu_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_pu_igm.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 hpgl using pu_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:pu_igm.obj=110aec0b3fd99a735f9f478fdb971e48d6791a9e691860f8db715674837a6a68
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_pu_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_pu_igm
+            +guid:d5444fd8-f44e-4d21-a4fa-2d85712ad04f
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_pu_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('110aec0b3fd99a735f9f478fdb971e48d6791a9e691860f8db715674837a6a68')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_rt_igm.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_hpgl_vector_rt_igm.py
@@ -1,0 +1,60 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+    
+        +purpose: pcl5 hpgl using rt_igm.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:rt_igm.obj=c923ecde57c4a63cc33a769235a24c575f49048f0598f2a2cc5ee26f2493fd4a
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_hpgl_vector_rt_igm_file_then_succeeds
+        +test:
+            +title: test_pcl5_hpgl_vector_rt_igm
+            +guid:ea87fd3e-0b57-417b-884c-adf168f08790
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_hpgl_vector_rt_igm_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('c923ecde57c4a63cc33a769235a24c575f49048f0598f2a2cc5ee26f2493fd4a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_1.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_1.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tgen_ac_1.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tgen_ac_1.obj=443db4a499875e2673ba08652ac91575c336db6cde24d391156c82a3b62e4868
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_arb_clipping_tgen_ac_1_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_arb_clipping_tgen_ac_1
+            +guid:218b3446-287d-4f07-8e4f-935859b3ecec
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_arb_clipping_tgen_ac_1_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('443db4a499875e2673ba08652ac91575c336db6cde24d391156c82a3b62e4868')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_11.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_11.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tgen_ac_11.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tgen_ac_11.obj=84b6278537d8f403e6a72a937e0adff1195f98cd94f44480d9def12d7aa546b9
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_arb_clipping_tgen_ac_11_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_arb_clipping_tgen_ac_11
+            +guid:a0647ed0-8dee-49af-b8e3-e6ca8b08818c
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_arb_clipping_tgen_ac_11_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('84b6278537d8f403e6a72a937e0adff1195f98cd94f44480d9def12d7aa546b9')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_3.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_3.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tgen_ac_3.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tgen_ac_3.obj=43b646118d62ea089af3b2bf600795be13693c6dbaf42f0676312449be896224
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_arb_clipping_tgen_ac_3_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_arb_clipping_tgen_ac_3
+            +guid:609c0f03-b46b-4d71-b933-0d2b3b607692
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_arb_clipping_tgen_ac_3_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('43b646118d62ea089af3b2bf600795be13693c6dbaf42f0676312449be896224')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_5.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_5.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tgen_ac_5.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tgen_ac_5.obj=b3725fe73cf460faafc53b222f8d6e178593040695fa744b230496e667d57ca9
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_arb_clipping_tgen_ac_5_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_arb_clipping_tgen_ac_5
+            +guid:005e5354-04b7-4a9e-bdac-5e2cea0533e9
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_arb_clipping_tgen_ac_5_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('b3725fe73cf460faafc53b222f8d6e178593040695fa744b230496e667d57ca9')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_6.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_6.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tgen_ac_6.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tgen_ac_6.obj=33bd88f67e335099f3ca78879fcf07466f44d313e44f90f5b404f380cc272a1d
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_arb_clipping_tgen_ac_6_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_arb_clipping_tgen_ac_6
+            +guid:67a92e38-9ede-4349-8da0-2429a1bdb4af
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_arb_clipping_tgen_ac_6_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('33bd88f67e335099f3ca78879fcf07466f44d313e44f90f5b404f380cc272a1d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_8.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_8.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tgen_ac_8.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tgen_ac_8.obj=a0998856dacc41b98ae45491820260579360a0732509ba5f50fa1f7730195992
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_arb_clipping_tgen_ac_8_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_arb_clipping_tgen_ac_8
+            +guid:c81fb9d6-9fcc-4a46-9ef1-a9ec0f81511a
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_arb_clipping_tgen_ac_8_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('a0998856dacc41b98ae45491820260579360a0732509ba5f50fa1f7730195992')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_9.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_arb_clipping_tgen_ac_9.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tgen_ac_9.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tgen_ac_9.obj=60e5dceab3916f4e6db2bd3f1c10001ee69925815a35ecc6ddd055c75d242d48
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_arb_clipping_tgen_ac_9_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_arb_clipping_tgen_ac_9
+            +guid:0bc51163-b311-4519-be33-c272628abc1b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_arb_clipping_tgen_ac_9_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('60e5dceab3916f4e6db2bd3f1c10001ee69925815a35ecc6ddd055c75d242d48')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cap_dotmoves.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cap_dotmoves.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using dotmoves.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:dotmoves.obj=92e1cb9259f45953cbb80545c4abc6a31dbd46cd8db6ae9e3394a61063ecef8f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_cap_dotmoves_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_cap_dotmoves
+            +guid:0b15a530-a844-4c12-a942-6e0957ddf881
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_cap_dotmoves_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('92e1cb9259f45953cbb80545c4abc6a31dbd46cd8db6ae9e3394a61063ecef8f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cap_ff.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cap_ff.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using ff.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ff.obj=e88d639adac70b0bd1608bd14e6b5ae3087ed223c2dc4b66d369920ae65477b6
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_cap_ff_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_cap_ff
+            +guid:d231c648-8a06-40d2-89bf-84dfc8abbbb2
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_cap_ff_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('e88d639adac70b0bd1608bd14e6b5ae3087ed223c2dc4b66d369920ae65477b6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cap_lf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cap_lf.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using lf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:lf.obj=349072e095fea4ece5e20548b808fe96a191345b31c8ad46c55007e83a25d85f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_cap_lf_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_cap_lf
+            +guid:3c37a61b-d0b0-431a-82ca-712255dce50e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_cap_lf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('349072e095fea4ece5e20548b808fe96a191345b31c8ad46c55007e83a25d85f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cap_ppptest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cap_ppptest.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using ppptest.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ppptest.obj=b8180cb31f5b19d8b09bf03ded01288f74026da4bc4e15d9b462d9f136b92a92
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_cap_ppptest_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_cap_ppptest
+            +guid:a9ae8e9b-7d6b-4b6d-8cc2-1586d9a7295b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+    
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_cap_ppptest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('b8180cb31f5b19d8b09bf03ded01288f74026da4bc4e15d9b462d9f136b92a92')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cap_textpath.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cap_textpath.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using textpath.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:textpath.obj=7df7b2357d909d0f0cae772f1f0ee2208ee23b599478746115386fc751b8c35f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_cap_textpath_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_cap_textpath
+            +guid:0a861c93-5d8c-4dc9-afc9-ce1a6e240ee3
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_cap_textpath_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('7df7b2357d909d0f0cae772f1f0ee2208ee23b599478746115386fc751b8c35f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cpedefects_cr43864_jobnamewithamp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cpedefects_cr43864_jobnamewithamp.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using JobNameWithAmp.pcl
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:JobNameWithAmp.pcl=625b148f1c8a268d5eaf3deca3a0231c72a43706ac51509ef47cc07f6ccf2c7a
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_cpedefects_cr43864_jobnamewithamp_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_cpedefects_cr43864_jobnamewithamp
+            +guid:2c6eafa2-e774-4f2b-aa6f-3da9695bc359
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_cpedefects_cr43864_jobnamewithamp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('625b148f1c8a268d5eaf3deca3a0231c72a43706ac51509ef47cc07f6ccf2c7a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cpedefects_lsg55412.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cpedefects_lsg55412.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using lsg55412.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:900
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:lsg55412.obj=0f04a706f7794ffb35058ace08612db5764ab4fd909bdce10c65ae2b332d298c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_cpedefects_lsg55412_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_cpedefects_lsg55412
+            +guid:0a6ea8cc-915f-4fbe-ad94-e248b0987981
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_cpedefects_lsg55412_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('0f04a706f7794ffb35058ace08612db5764ab4fd909bdce10c65ae2b332d298c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cpedefects_lsg55412_lsg55412_jedi.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_cpedefects_lsg55412_lsg55412_jedi.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using lsg55412_jedi.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:lsg55412_jedi.obj=e4de3a73235334f72742ca56e76a4b3538b9093adccda95007eefff88bff2d3d
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_cpedefects_lsg55412_lsg55412_jedi_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_cpedefects_lsg55412_lsg55412_jedi
+            +guid:79bc040e-a330-4d5d-b2a1-fd0c35643734
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_cpedefects_lsg55412_lsg55412_jedi_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('e4de3a73235334f72742ca56e76a4b3538b9093adccda95007eefff88bff2d3d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplexm1.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplexm1.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using duplexm1.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:duplexm1.obj=2642f51d4ae725be11414687afddf83399ccd4f72aa4c3b0d4fe0b9a4e568c8e
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_duplex_duplexm1_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_duplex_duplexm1
+            +guid:70b621ab-24da-4c11-901d-e905cf5f96eb
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_duplex_duplexm1_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2642f51d4ae725be11414687afddf83399ccd4f72aa4c3b0d4fe0b9a4e568c8e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplexm3.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplexm3.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using duplexm3.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:duplexm3.obj=431098ccfa7e7d5e3c7b944cbde807d467a9d1d55d74db1ed3529208680747be
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_duplex_duplexm3_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_duplex_duplexm3
+            +guid:646091aa-4501-4744-bf50-a5391b5258dd
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_duplex_duplexm3_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('431098ccfa7e7d5e3c7b944cbde807d467a9d1d55d74db1ed3529208680747be')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplexm6.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplexm6.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using duplexm6.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:duplexm6.obj=e84565b2524d9a77e9d6cc9d7a846c4d80f4f6c2c81d2f00111ca48c891b59df
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_duplex_duplexm6_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_duplex_duplexm6
+            +guid:ba448962-dede-4db1-9eaa-5bb4baf31b31
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_duplex_duplexm6_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('e84565b2524d9a77e9d6cc9d7a846c4d80f4f6c2c81d2f00111ca48c891b59df')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplx5a.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplx5a.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using duplx5a.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:duplx5a.obj=9fbfe048f4a6fdfc5547471e0d0757bc945dc41ae4d5f192e4692f9a5a947b61
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_duplex_duplx5a_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_duplex_duplx5a
+            +guid:3fc5dae3-8c6d-4efd-9f76-36cd4fe789b3
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_duplex_duplx5a_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('9fbfe048f4a6fdfc5547471e0d0757bc945dc41ae4d5f192e4692f9a5a947b61')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplx5b1.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplx5b1.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using duplx5b1.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:duplx5b1.obj=de6515e52101cc24620a028c97f50b41b01afb91616161bcfa0f8b2c746f9d18
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_duplex_duplx5b1_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_duplex_duplx5b1
+            +guid:679b3c7c-b10b-4542-95ad-26b1f06b8cc0
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_duplex_duplx5b1_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('de6515e52101cc24620a028c97f50b41b01afb91616161bcfa0f8b2c746f9d18')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplx5b2.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplx5b2.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using duplx5b2.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:1020
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:duplx5b2.obj=d0fabfe926e944b7532b5b14cfdf994e95b35ed4ff6ed4bcc10518c0b4e04444
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_duplex_duplx5b2_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_duplex_duplx5b2
+            +guid:6d4d0ff0-fe27-445d-9147-c9536b55a584
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_duplex_duplx5b2_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('d0fabfe926e944b7532b5b14cfdf994e95b35ed4ff6ed4bcc10518c0b4e04444')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplx5b3.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplx5b3.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using duplx5b3.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:720
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:duplx5b3.obj=cb3d70041ca32fa8457d8cb45d253c0dc4646cd4247d9d179382c72157fc754d
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_duplex_duplx5b3_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_duplex_duplx5b3
+            +guid:4abea9a9-f6fc-4670-96bc-7eb9df650655
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_duplex_duplx5b3_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('cb3d70041ca32fa8457d8cb45d253c0dc4646cd4247d9d179382c72157fc754d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplx5c.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplx5c.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using duplx5c.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:duplx5c.obj=2a3914c70ac0278769747ed884b085473018be5dcdd78e8c70720ac911623eba
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_duplex_duplx5c_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_duplex_duplx5c
+            +guid:d249a7e0-b88c-4d5e-bc4a-77dff1e23ecd
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_duplex_duplx5c_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2a3914c70ac0278769747ed884b085473018be5dcdd78e8c70720ac911623eba')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplx5e.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_duplex_duplx5e.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using duplx5e.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:duplx5e.obj=4c228bcd20a780d776d30f9d4692d1d16d00734b0f4f60fb2beca9c8502eda2a
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_duplex_duplx5e_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_duplex_duplx5e
+            +guid:1e8656bd-696e-4d30-ae93-ea4c033e679e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_duplex_duplx5e_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('4c228bcd20a780d776d30f9d4692d1d16d00734b0f4f60fb2beca9c8502eda2a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_andale_selectandalefont_resourcedata.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_andale_selectandalefont_resourcedata.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using selectandalefont_resourcedata.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:selectandalefont_resourcedata.obj=3c1d3b80028227b3c898b588995b30ee09563222b900c11d220ed59f5430c34e
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_andale_selectandalefont_resourcedata_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_font_andale_selectandalefont_resourcedata
+            +guid:c712c38f-e447-4278-b1b3-374d373a9dfd
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_andale_selectandalefont_resourcedata_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('3c1d3b80028227b3c898b588995b30ee09563222b900c11d220ed59f5430c34e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_ffont_cf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_ffont_cf.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using ffont_cf.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:ffont_cf.obj=2536aef0c2d4a9d93d79c77f23328dce84017419f126202bec530f8a7faa79fa
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_ffont_cf_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_font_feature_ffont_cf
+            +guid:b9f47ad4-6ac3-4f7d-ac68-965f9c0044c9
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_ffont_cf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2536aef0c2d4a9d93d79c77f23328dce84017419f126202bec530f8a7faa79fa')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_ffont_cf_hw.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_ffont_cf_hw.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using ffont_cf_hw.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:ffont_cf_hw.obj=278b1cfca8fd44965c7defe545ddd79755b8386f438fe8347b2d6332d0738b5a
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_ffont_cf_hw_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_font_feature_ffont_cf_hw
+            +guid:6ef3f3be-74bc-4e47-9b93-d04878d89f66
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_ffont_cf_hw_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('278b1cfca8fd44965c7defe545ddd79755b8386f438fe8347b2d6332d0738b5a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_fmacro_cf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_fmacro_cf.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using fmacro_cf.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:fmacro_cf.obj=fdd2646e64ed67ae4bc2223e65099055091c3e3fd70942498f8969ffbaf5a1f2
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_fmacro_cf_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_font_feature_fmacro_cf
+            +guid:86e1ccef-7983-4037-954c-a9a7f75b5234
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_fmacro_cf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('fdd2646e64ed67ae4bc2223e65099055091c3e3fd70942498f8969ffbaf5a1f2')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_fmacro_cf_hw.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_fmacro_cf_hw.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using fmacro_cf_hw.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:fmacro_cf_hw.obj=62eda5337b7c2f0bf18898bf0e660b4e1c68befb22da2cbea6f65338993f9998
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_fmacro_cf_hw_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_font_feature_fmacro_cf_hw
+            +guid:31d8a86d-83e8-4bb3-9f84-f1a7f7c6d8f6
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_fmacro_cf_hw_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('62eda5337b7c2f0bf18898bf0e660b4e1c68befb22da2cbea6f65338993f9998')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_gpri_1.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_gpri_1.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using gpri_1.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:700
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:gpri_1.obj=4ed43cc07955a637a61f509540d6ec5b86512b8329a598b8fa026eba83df9c57
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_gpri_1_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_font_feature_gpri_1
+            +guid:4199573a-8152-4b4a-ba7f-2ef37739ad7c
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_gpri_1_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('4ed43cc07955a637a61f509540d6ec5b86512b8329a598b8fa026eba83df9c57')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_mult_gfont.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_mult_gfont.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using mult_gfont.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:mult_gfont.obj=85ea5840a6b4e6e115d6a2806d8f265cc4109b3facb493d765f4aff67611ba45
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_mult_gfont_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_font_feature_mult_gfont
+            +guid:9a9ec2bb-6dd2-4826-819e-f738fa2a2b86
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_mult_gfont_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('85ea5840a6b4e6e115d6a2806d8f265cc4109b3facb493d765f4aff67611ba45')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_overpri_1.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_overpri_1.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using overpri_1.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:overpri_1.obj=5b81d8d80cef61012435a4d8e7359fbb9db8ec99c6b7acab4a14aee2b072e174
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_overpri_1_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_font_feature_overpri_1
+            +guid:a258e30c-7f1a-42fa-8b17-c64d7af54111
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_overpri_1_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('5b81d8d80cef61012435a4d8e7359fbb9db8ec99c6b7acab4a14aee2b072e174')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fmacro_cf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fmacro_cf.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using usb_fmacro_cf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:usb_fmacro_cf.obj=2bec6274ea7becdf534a323576bb64b9946e5525214e13dd1759ebb6e2172dfe
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_usb_fmacro_cf_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_font_feature_usb_fmacro_cf
+            +guid:8df20faf-c599-4e7a-9b1e-8fa3fccee66e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_usb_fmacro_cf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2bec6274ea7becdf534a323576bb64b9946e5525214e13dd1759ebb6e2172dfe')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_11.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_11.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using usb_fpri_11.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:usb_fpri_11.obj=8e30d0ef2f9adc94338ed403a2d42ebb8c3ab8ba0a5e9d0bce8d12e40059744b
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_usb_fpri_11_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_font_feature_usb_fpri_11
+            +guid:ebbb94ef-ab78-40d1-92fc-2bfd5611a515
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_usb_fpri_11_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('8e30d0ef2f9adc94338ed403a2d42ebb8c3ab8ba0a5e9d0bce8d12e40059744b')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_12.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_12.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using usb_fpri_12.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:usb_fpri_12.obj=2cb44358c592547b761d0956b495b0c6d5eec481c6baea4ffa1c24d875d0ca6e
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_usb_fpri_12_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_font_feature_usb_fpri_12
+            +guid:823a7564-de71-4624-9d20-2495dd0ca770
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_usb_fpri_12_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2cb44358c592547b761d0956b495b0c6d5eec481c6baea4ffa1c24d875d0ca6e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_13.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_13.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using usb_fpri_13.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:usb_fpri_13.obj=a10cc6bbff29c0e27bcb45ebdc3513a12f939102e0e38b98a4c115c99a86b8ab
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_usb_fpri_13_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_font_feature_usb_fpri_13
+            +guid:c4ca17a5-2633-492d-9e77-f7c2fbdd60b4
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_usb_fpri_13_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('a10cc6bbff29c0e27bcb45ebdc3513a12f939102e0e38b98a4c115c99a86b8ab')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_6.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_6.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using usb_fpri_6.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:usb_fpri_6.obj=f79ee31f938564e79e4cadc702ab93ddeeb5ba53492788129b73b2f18ab8572a
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_usb_fpri_6_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_font_feature_usb_fpri_6
+            +guid:968f910a-e01f-4fc2-a14e-dc046fef7fe9
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_usb_fpri_6_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('f79ee31f938564e79e4cadc702ab93ddeeb5ba53492788129b73b2f18ab8572a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_8.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_8.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using usb_fpri_8.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:usb_fpri_8.obj=c2b73fd9f28b6fe78084f714743f904fa1ebfad734af40057a67458cdf11af5e
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_usb_fpri_8_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_font_feature_usb_fpri_8
+            +guid:ac58d253-1599-4af1-a362-42a4d8050824
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_usb_fpri_8_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('c2b73fd9f28b6fe78084f714743f904fa1ebfad734af40057a67458cdf11af5e')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_8_hw.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_8_hw.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using usb_fpri_8_hw.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:usb_fpri_8_hw.obj=a3d6425ec44e0c3800d80e3b2a443cee94bb003e197c39885e7a7423d985aa01
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_usb_fpri_8_hw_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_font_feature_usb_fpri_8_hw
+            +guid:e1917a02-9e64-47fe-9ce6-efc2f149ed68
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_usb_fpri_8_hw_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('a3d6425ec44e0c3800d80e3b2a443cee94bb003e197c39885e7a7423d985aa01')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_9.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_fpri_9.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using usb_fpri_9.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:usb_fpri_9.obj=71a25c4db74bcb0e8bc79c9bf4d119c47c72ed99f7e3695f57c3e3af2e1ed34d
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_usb_fpri_9_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_font_feature_usb_fpri_9
+            +guid:451846f7-ce04-4bde-b0d7-db59f31f346d
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_usb_fpri_9_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('71a25c4db74bcb0e8bc79c9bf4d119c47c72ed99f7e3695f57c3e3af2e1ed34d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_gpri_1.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_gpri_1.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using usb_gpri_1.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:usb_gpri_1.obj=a8310d818f3112bdd9fc2c1d1bd837c9ce5308a372add182643dad35f3bd470b
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_usb_gpri_1_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_font_feature_usb_gpri_1
+            +guid:ba5dcf8f-a64a-4509-9e8d-4462e094ee60
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_usb_gpri_1_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('a8310d818f3112bdd9fc2c1d1bd837c9ce5308a372add182643dad35f3bd470b')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_mult_gfont.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_mult_gfont.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using usb_mult_gfont.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:usb_mult_gfont.obj=a17c75617979d2f5eaaf03e88fd56f766cfc81eb5a68c13b908a21602ff3f139
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_usb_mult_gfont_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_font_feature_usb_mult_gfont
+            +guid:33e1a4ec-a3a8-4e46-b406-6ccff37a95fc
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_usb_mult_gfont_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('a17c75617979d2f5eaaf03e88fd56f766cfc81eb5a68c13b908a21602ff3f139')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_overpri_1_hw.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_font_feature_usb_overpri_1_hw.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using usb_overpri_1_hw.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:usb_overpri_1_hw.obj=92a96bbec4dc8947e6aff15071440925a04aa2de599982f3196b645ac39d4129
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_font_feature_usb_overpri_1_hw_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_font_feature_usb_overpri_1_hw
+            +guid:62ed0bae-a838-4690-96d8-8084e0cb61ab
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_font_feature_usb_overpri_1_hw_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('92a96bbec4dc8947e6aff15071440925a04aa2de599982f3196b645ac39d4129')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jgoth.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jgoth.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using jgoth.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jgoth.obj=e9bf371a76d15687e1e7f3b621e0380811d23cb8291c7bb386b9f3687909843c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_jgoth_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_jgoth
+            +guid:35b231a1-35f5-4ea5-a415-8c15d7ccd9b6
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_jgoth_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('e9bf371a76d15687e1e7f3b621e0380811d23cb8291c7bb386b9f3687909843c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jminch.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jminch.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using jminch.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jminch.obj=cae001cccccdd925bf8c6ceb482ef1568712f039fcad5b59e90538213e3a661c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_jminch_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_jminch
+            +guid:39ccf30e-e76d-47aa-8962-62e7c41653d4
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_jminch_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('cae001cccccdd925bf8c6ceb482ef1568712f039fcad5b59e90538213e3a661c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpgoth.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpgoth.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using jpgoth.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jpgoth.obj=9d94926deb05a308447141505fd78b6e544908bcb856d0b0689131636e40a584
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpgoth_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_jpgoth
+            +guid:60d842f4-1aaa-4b65-955e-dcddb9be0d23
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpgoth_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('9d94926deb05a308447141505fd78b6e544908bcb856d0b0689131636e40a584')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpminch.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpminch.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using jpminch.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jpminch.obj=db8dba0a0df1ed397cdafca148654bbe422722d98ec85e358470713cd5e8dabf
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpminch_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_jpminch
+            +guid:042ed385-830e-48b6-8b52-cfef25c3e3d0
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpminch_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('db8dba0a0df1ed397cdafca148654bbe422722d98ec85e358470713cd5e8dabf')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpminchbd.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpminchbd.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using jpminchbd.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jpminchbd.obj=ed64a736d26f3fd29aaf65a6b59caa57419036747d6bcc1736fb5a41be1cbbd5
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpminchbd_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_jpminchbd
+            +guid:faae7c2f-7a4f-4846-8989-15740f6d2641
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpminchbd_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('ed64a736d26f3fd29aaf65a6b59caa57419036747d6bcc1736fb5a41be1cbbd5')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpminchit.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpminchit.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using jpminchit.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jpminchit.obj=d6ce8bd9042896bfc3627860b28b3be9bb32ee77fb0b071dee8628e07eecab3c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpminchit_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_jpminchit
+            +guid:e6b445a2-3c05-4dcb-83ab-a7fe8672b3da
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpminchit_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('d6ce8bd9042896bfc3627860b28b3be9bb32ee77fb0b071dee8628e07eecab3c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpminchv.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpminchv.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using jpminchv.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jpminchv.obj=b04589b07c41f7cd372cb31d1658301a06485926b4131e685a871892ab27304a
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpminchv_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_jpminchv
+            +guid:a5496745-ced1-4972-9088-d3fac14eab3a
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpminchv_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('b04589b07c41f7cd372cb31d1658301a06485926b4131e685a871892ab27304a')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpminchx.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpminchx.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using jpminchx.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jpminchx.obj=fc7f11462113124a74eeeebe8f886e66ad7a914a0634f9ab70ce51f4d631eac4
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpminchx_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_jpminchx
+            +guid:01ff06bb-bb48-4262-a527-b18c43099f48
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpminchx_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('fc7f11462113124a74eeeebe8f886e66ad7a914a0634f9ab70ce51f4d631eac4')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpminchy.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_jpminchy.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using jpminchy.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jpminchy.obj=d684d33a974576c22bf9c6dd9367ca755f7b88a42b96f5481c3304b1d0b260c8
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpminchy_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_jpminchy
+            +guid:56c0c3b0-813f-4cf7-ad7d-5798bb19b75e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_jpminchy_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('d684d33a974576c22bf9c6dd9367ca755f7b88a42b96f5481c3304b1d0b260c8')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kbatcf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kbatcf.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kbatcf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kbatcf.obj=4a8469deea4e4db35f0891940821627dcc3792f1dec79bd42401ee160b98e853
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_kbatcf_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_kbatcf
+            +guid:3338f06b-93c5-417d-91c0-0fad18f5ee66
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_kbatcf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('4a8469deea4e4db35f0891940821627dcc3792f1dec79bd42401ee160b98e853')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kbatcp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kbatcp.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kbatcp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kbatcp.obj=c94041fb912e05a548e466d38d87175ff10cdd894ca30a88532545b6e47a2ab5
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_kbatcp_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_kbatcp
+            +guid:7f902b41-a927-4eb0-a141-b48e2a75075a
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_kbatcp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('c94041fb912e05a548e466d38d87175ff10cdd894ca30a88532545b6e47a2ab5')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kdotcf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kdotcf.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kdotcf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kdotcf.obj=d47a1179e30c81e15ff62f1002a2d60e68413619f5ba7958c7eb07ec5ed00fd6
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_kdotcf_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_kdotcf
+            +guid:8fb31bc2-88db-4a8b-8cf4-c39bdef38dfe
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_kdotcf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('d47a1179e30c81e15ff62f1002a2d60e68413619f5ba7958c7eb07ec5ed00fd6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kdotcp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kdotcp.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kdotcp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kdotcp.obj=5b051f8e6bfefe6e6cc825b0774c888798f345423701f0c01d32d23da431e393
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_kdotcp_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_kdotcp
+            +guid:e9a4664c-0861-468e-aa56-fa7a550bcc0b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_kdotcp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('5b051f8e6bfefe6e6cc825b0774c888798f345423701f0c01d32d23da431e393')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kdotcpit.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kdotcpit.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kdotcpit.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kdotcpit.obj=6c7841622848dad4b62e1f097d818f91d9f5b0d8768bbef199766b16dffc7466
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_kdotcpit_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_kdotcpit
+            +guid:1f756513-5283-4855-8b85-e6e2740c0c86
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_kdotcpit_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('6c7841622848dad4b62e1f097d818f91d9f5b0d8768bbef199766b16dffc7466')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kdotcpv.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kdotcpv.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kdotcpv.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:720
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kdotcpv.obj=c1e4f43488fa6eaaa15edb81085e077ab10f1b0aa93d7c5160139c76ca4a9604
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_kdotcpv_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_kdotcpv
+            +guid:e79cbf1d-6036-4f59-98d4-cf15beed8e1a
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_kdotcpv_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('c1e4f43488fa6eaaa15edb81085e077ab10f1b0aa93d7c5160139c76ca4a9604')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kdotcpx.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kdotcpx.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kdotcpx.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kdotcpx.obj=dc0d08ffb0de1961c304bd92582c2119acb2dc696d9e49e898e5356315326ed6
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_kdotcpx_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_kdotcpx
+            +guid:29690ae4-f238-475e-bdfd-aecfef223b77
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_kdotcpx_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('dc0d08ffb0de1961c304bd92582c2119acb2dc696d9e49e898e5356315326ed6')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kdotcpy.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kdotcpy.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kdotcpy.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kdotcpy.obj=6d11e8076569a514ac9eb3ffa1bd53e38140626db15cbb418ec5703f974fad50
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_kdotcpy_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_kdotcpy
+            +guid:97c2cdec-e69b-42e4-9d9e-e0376abeebf1
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_kdotcpy_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('6d11e8076569a514ac9eb3ffa1bd53e38140626db15cbb418ec5703f974fad50')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kgulcf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kgulcf.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kgulcf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kgulcf.obj=dc31ac8bb908f6b69fa9f682126d210998bbb4635e9a2abd752dcf2664f07848
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_kgulcf_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_kgulcf
+            +guid:36d3cd1c-970c-4ca2-9e75-3b408f8b2f3f
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_kgulcf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('dc31ac8bb908f6b69fa9f682126d210998bbb4635e9a2abd752dcf2664f07848')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kgulcp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kgulcp.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kgulcp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kgulcp.obj=49f717e3969bf3079365b1936d4e51aa5cc71cbaec4b18cafdf2dc649ab2b5fb
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_kgulcp_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_kgulcp
+            +guid:71aaa9bf-34ee-4c22-9cc6-89660a27cb4e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_kgulcp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('49f717e3969bf3079365b1936d4e51aa5cc71cbaec4b18cafdf2dc649ab2b5fb')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kgungcf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_kgungcf.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kgungcf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kgungcf.obj=7b709ae51ba0831a8db5494258467d55b0933d076e1c9f40a2c5ed1b586a0bb7
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_kgungcf_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_kgungcf
+            +guid:c38853c5-00f3-4984-b123-6f48b8a05d5e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_kgungcf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('7b709ae51ba0831a8db5494258467d55b0933d076e1c9f40a2c5ed1b586a0bb7')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khybatf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khybatf.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using khybatf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:khybatf.obj=f0f8241e79c3ded5a05657f04915ddc330793eb897d2cf8033c983316e903352
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_khybatf_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_khybatf
+            +guid:a4b2d5e5-bac1-44bf-9240-5f8069ed4d77
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_khybatf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('f0f8241e79c3ded5a05657f04915ddc330793eb897d2cf8033c983316e903352')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khybatp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khybatp.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using khybatp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:khybatp.obj=6ddd3d573b3606c9859b33c3c574020ceafb00b050c9b61fb212fc7355ffde69
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_khybatp_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_khybatp
+            +guid:a0135d4f-5328-4a16-ae64-9ec2a9698394
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_khybatp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('6ddd3d573b3606c9859b33c3c574020ceafb00b050c9b61fb212fc7355ffde69')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khydotf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khydotf.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using khydotf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:khydotf.obj=4911ac617698208f57319c58d45865a721439db6b76657370629c67dbedbcba2
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_khydotf_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_khydotf
+            +guid:db61732e-b1cd-4922-b5c1-b262a75d5a08
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_khydotf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('4911ac617698208f57319c58d45865a721439db6b76657370629c67dbedbcba2')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khydotp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khydotp.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using khydotp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:khydotp.obj=6e09368cabbb1945e571fc36477d9d9734a364a04dc795ded02919bc7b9c24a0
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_khydotp_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_khydotp
+            +guid:b974c4fe-0590-4aa9-8752-498d6c95f84e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_khydotp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('6e09368cabbb1945e571fc36477d9d9734a364a04dc795ded02919bc7b9c24a0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulf.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using khygulf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:khygulf.obj=baf0ae4241e11668cb96ee61773970b7d9147c17c1b67156e5a9457f58cd3dc9
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulf_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_khygulf
+            +guid:b6311b8e-5e44-42c0-b46c-484a32c1601e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('baf0ae4241e11668cb96ee61773970b7d9147c17c1b67156e5a9457f58cd3dc9')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulfbd.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulfbd.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using khygulfbd.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:khygulfbd.obj=f8549634e915fad8a93987dff3c41b377b09cb401e3996fd4ac0523d083ccf28
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulfbd_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_khygulfbd
+            +guid:b87c8a1e-cfd2-4246-aa16-bf8fdd9caff6
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulfbd_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('f8549634e915fad8a93987dff3c41b377b09cb401e3996fd4ac0523d083ccf28')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulfit.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulfit.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using khygulfit.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:720
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:khygulfit.obj=1ba204bc0365eea9235d04b97dcd735355f1ede00bd0f1a9d1380c34d3c12cc2
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulfit_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_khygulfit
+            +guid:8947f930-575b-4c9d-8424-e236bbf58c1b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulfit_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('1ba204bc0365eea9235d04b97dcd735355f1ede00bd0f1a9d1380c34d3c12cc2')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulfv.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulfv.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using khygulfv.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:khygulfv.obj=304e500068b9c63a191eda0e2aade5b135faa8debd7cb80c72ac07bfd2c8fa8c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulfv_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_khygulfv
+            +guid:2dd2767d-df06-4d34-a819-8064384b5eb9
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulfv_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('304e500068b9c63a191eda0e2aade5b135faa8debd7cb80c72ac07bfd2c8fa8c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulfx.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulfx.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using khygulfx.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:khygulfx.obj=c65c9446c1af8774ee661c9fc97dd41bd0fb2b45a60d69f4fd09cfa71197c9c9
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulfx_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_khygulfx
+            +guid:c17bc2b9-b4c8-4212-b73a-69bcbf702f95
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulfx_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('c65c9446c1af8774ee661c9fc97dd41bd0fb2b45a60d69f4fd09cfa71197c9c9')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulfy.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulfy.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using khygulfy.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:khygulfy.obj=e6973c92ef0406aab19c9f1d29b1a3213dd5deef80d9d780996ee6fd65208861
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulfy_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_khygulfy
+            +guid:b31deb89-158d-459a-a46a-533a9d5c2eb3
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulfy_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('e6973c92ef0406aab19c9f1d29b1a3213dd5deef80d9d780996ee6fd65208861')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygulp.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using khygulp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:khygulp.obj=8664cfb7eb34c03e9dbe13a9befbf51a96d9721d4d2a4a1417c8cd1a9b423963
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulp_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_khygulp
+            +guid:dc9256f2-1962-4dff-bd2c-f52ac973e812
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygulp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('8664cfb7eb34c03e9dbe13a9befbf51a96d9721d4d2a4a1417c8cd1a9b423963')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygungf.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygungf.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using khygungf.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:khygungf.obj=cbe3fcd8bfa5b5cb103a7aa2847bc1850a843e37fe3896d59f770fd18a652219
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygungf_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_khygungf
+            +guid:c067add3-966a-4849-8831-2afda2bb06a4
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygungf_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('cbe3fcd8bfa5b5cb103a7aa2847bc1850a843e37fe3896d59f770fd18a652219')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygungp.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_khygungp.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using khygungp.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:khygungp.obj=8af6745dfbf2fcd47f6fcd1b936cb4a561edc0472b1ed41bd6b50f93d89bd2b0
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygungp_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_khygungp
+            +guid:0914676f-d87b-4155-a899-fdb268e03f7a
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_khygungp_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('8af6745dfbf2fcd47f6fcd1b936cb4a561edc0472b1ed41bd6b50f93d89bd2b0')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scsfang.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scsfang.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using scsfang.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:scsfang.obj=ccdc23daa1be92de8b67fe598eabefc21bbbb701ed8f3448339f52c0dca7eda5
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_scsfang_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_scsfang
+            +guid:edffb09e-346b-4727-a9e8-d8de683a2e85
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_scsfang_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('ccdc23daa1be92de8b67fe598eabefc21bbbb701ed8f3448339f52c0dca7eda5')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scsfangbd.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scsfangbd.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using scsfangbd.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:scsfangbd.obj=f38d4bf9d6b234abee79ff36cb6e84ce154ee8305e2f22755af92c7f90335d12
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_scsfangbd_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_scsfangbd
+            +guid:92a94a63-1563-4bc9-b2bb-0ad40c47f31f
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_scsfangbd_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('f38d4bf9d6b234abee79ff36cb6e84ce154ee8305e2f22755af92c7f90335d12')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scsfangit.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scsfangit.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using scsfangit.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:scsfangit.obj=d7d62ec91c25ff9426e87f5946d3239d400788d8fd2046b795466394d1506e22
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_scsfangit_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_scsfangit
+            +guid:195ecc9f-f68b-43c8-b4fd-81a47cf5c89f
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_scsfangit_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('d7d62ec91c25ff9426e87f5946d3239d400788d8fd2046b795466394d1506e22')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scsfangv.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scsfangv.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using scsfangv.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:scsfangv.obj=7f87558523fb0ab9cb03bdf7ffd8d67ac9b8eda125917be35a099dd79b96970f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_scsfangv_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_scsfangv
+            +guid:dcd8701d-8279-4b6f-accf-f16657a9bcc6
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_scsfangv_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('7f87558523fb0ab9cb03bdf7ffd8d67ac9b8eda125917be35a099dd79b96970f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scsfangx.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scsfangx.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using scsfangx.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:scsfangx.obj=e78be68b0c70476078124d5f8100e8e00f081293868c8dd0265d2a0d8e8044d4
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_scsfangx_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_scsfangx
+            +guid:bbee1c58-47c6-42ca-9431-e44a933b8f45
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_scsfangx_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('e78be68b0c70476078124d5f8100e8e00f081293868c8dd0265d2a0d8e8044d4')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scshei.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scshei.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using scshei.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:scshei.obj=b40642733d1c66abd8fc8cec8edbf2357612c4458320f70f44109fa203a89086
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_scshei_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_scshei
+            +guid:ab192de8-bbd4-468f-9f08-d9562fe69a4f
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_scshei_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('b40642733d1c66abd8fc8cec8edbf2357612c4458320f70f44109fa203a89086')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scskai.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scskai.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using scskai.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:scskai.obj=5e6b3d95968dfda324998c092947c4c1ea5b904262b311c95f95dcb3a6be0c28
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_scskai_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_scskai
+            +guid:f26b8727-4ca4-4f23-ab6d-8b111125a473
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_scskai_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('5e6b3d95968dfda324998c092947c4c1ea5b904262b311c95f95dcb3a6be0c28')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scssun.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_scssun.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using scssun.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:scssun.obj=55ae56ee185c1ec5b3c43411db036021a90116963a1ffe8d60541027097abb66
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_scssun_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_scssun
+            +guid:383450a5-ae9e-46b7-885b-08ab8de0eb69
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_scssun_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('55ae56ee185c1ec5b3c43411db036021a90116963a1ffe8d60541027097abb66')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tckai.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tckai.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tckai.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tckai.obj=4b969c90b9e8b787fc13669e65ac9c5af7c7f666d59e4ed5d4394416df819145
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_tckai_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_tckai
+            +guid:8276fa28-e9de-4f5e-9c72-8c10e51a03b5
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_tckai_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('4b969c90b9e8b787fc13669e65ac9c5af7c7f666d59e4ed5d4394416df819145')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcming.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcming.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tcming.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tcming.obj=833a83396e674f1cad37d1a63c8eac0d541abfd41478e244cd8d9da30fa15e8c
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcming_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_tcming
+            +guid:2812e218-b44c-455f-bccf-acef5510c403
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcming_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('833a83396e674f1cad37d1a63c8eac0d541abfd41478e244cd8d9da30fa15e8c')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcpming.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcpming.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tcpming.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tcpming.obj=7baeacc8b66ab0c14660ba752a872654b8c59cb2beb7b088de932ec6cbc89ed2
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcpming_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_tcpming
+            +guid:d99d66cd-5e43-45c6-a721-11485746b1e8
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcpming_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('7baeacc8b66ab0c14660ba752a872654b8c59cb2beb7b088de932ec6cbc89ed2')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcpmingbd.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcpmingbd.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tcpmingbd.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:720
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tcpmingbd.obj=264db56a438f50e44bc234f1b5510359b8993c7f7ec773902e4ea54065090099
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcpmingbd_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_tcpmingbd
+            +guid:597ba3d0-a433-4982-84a7-9ffaa0ab4f2b
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcpmingbd_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('264db56a438f50e44bc234f1b5510359b8993c7f7ec773902e4ea54065090099')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcpmingit.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcpmingit.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tcpmingit.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tcpmingit.obj=f278735a3e74e9b94605dd26dd8bfe16a1f9b58b9bc8788501a74cb8611cf82f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcpmingit_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_tcpmingit
+            +guid:cf093e65-9f1f-4630-9631-7bac32e73eb7
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcpmingit_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('f278735a3e74e9b94605dd26dd8bfe16a1f9b58b9bc8788501a74cb8611cf82f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcpmingv.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcpmingv.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tcpmingv.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tcpmingv.obj=d8812203309c41075bf6303e9141cc1006d07ba49758b59b02a376c70d9d8a2f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcpmingv_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_tcpmingv
+            +guid:131f1654-40b3-479c-8748-5352f9537bd4
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcpmingv_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('d8812203309c41075bf6303e9141cc1006d07ba49758b59b02a376c70d9d8a2f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcpmingx.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcpmingx.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tcpmingx.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tcpmingx.obj=45b7a0bedc72b716a6940b258ef01c0c64e649497c0cb03182c9acaa11a428ff
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcpmingx_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_tcpmingx
+            +guid:47ac6287-ce4f-4589-b50d-4043959884b1
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcpmingx_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('45b7a0bedc72b716a6940b258ef01c0c64e649497c0cb03182c9acaa11a428ff')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcpmingy.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_2bytetypeface_tcpmingy.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tcpmingy.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tcpmingy.obj=f0a14bad3523cf5e87f530a41d2bd3256d8245270736da1d74332057d09d9c46
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcpmingy_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_2bytetypeface_tcpmingy
+            +guid:110b0b1e-82c4-48a8-a3fa-1078884a3c51
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_2bytetypeface_tcpmingy_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('f0a14bad3523cf5e87f530a41d2bd3256d8245270736da1d74332057d09d9c46')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_fntfmt16.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_fntfmt16.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using fmt16bmp.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:fmt16bmp.obj=8b18964a2a8183ad373fdb1e32618f0b6fcdf289854daa8aededae83e2ba8b39
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_fntfmt16_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_fontdes_fntfmt16
+            +guid:e53e4f16-1a11-4293-9e7b-6182ad2682d1
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_fntfmt16_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('8b18964a2a8183ad373fdb1e32618f0b6fcdf289854daa8aededae83e2ba8b39')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_fntfmt16_fmt16seg.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_fntfmt16_fmt16seg.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using fmt16seg.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:fmt16seg.obj=70a67a3e8248a4d499efa4a28fd11b9cd73f2aa3f42917a8612507fd18cf561d
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_fntfmt16_fmt16seg_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_fntfmt16_fmt16seg
+            +guid:3c3ff1b5-5c84-4361-90df-244387006cb8
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_fntfmt16_fmt16seg_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('70a67a3e8248a4d499efa4a28fd11b9cd73f2aa3f42917a8612507fd18cf561d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_font_pri_diskpri.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_font_pri_diskpri.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using diskpri.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:diskpri.obj=3f5b0bcb39e2b3f5a6044347b46db88aed11508feafce275a68eb7d468eec8e7
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_font_pri_diskpri_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_fontdes_font_pri_diskpri
+            +guid:5cb78366-d977-458b-8105-79b7cd9af329
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_font_pri_diskpri_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('3f5b0bcb39e2b3f5a6044347b46db88aed11508feafce275a68eb7d468eec8e7')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_font_pri_fpri300.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_font_pri_fpri300.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using fpri300.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:fpri300.obj=92ea696bd1fa2f8140e5478332a8c2ab94034f99e69a3d7a6ab4acb34a3e7f2f
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_font_pri_fpri300_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_font_pri_fpri300
+            +guid:4c9ced36-2211-4984-b83e-81a83f925c1e
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_font_pri_fpri300_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('92ea696bd1fa2f8140e5478332a8c2ab94034f99e69a3d7a6ab4acb34a3e7f2f')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_font_pri_simmpri.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_font_pri_simmpri.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using simmpri.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:simmpri.obj=e5910dd4a7ed941d330d3359102f315d689f21fe6c6b4f1317c4654ddaf61c8d
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_font_pri_simmpri_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_font_pri_simmpri
+            +guid:0070b206-4847-4056-bf1a-6b8c1e910beb
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_font_pri_simmpri_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('e5910dd4a7ed941d330d3359102f315d689f21fe6c6b4f1317c4654ddaf61c8d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_fontpri5.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_fontpri5.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using fontpri5.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:fontpri5.obj=7aa4e90fc2b60f30cbe8a6591b052d84ce60e43139d056e0a0045dc0467d9ab2
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_fontpri5_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_fontpri5
+            +guid:b5da0343-4c12-4038-84fd-580ebdeeae38
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_fontpri5_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('7aa4e90fc2b60f30cbe8a6591b052d84ce60e43139d056e0a0045dc0467d9ab2')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_jbdtest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_jbdtest.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using jbdtest.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jbdtest.obj=07442f34fd81b7c60e3420689864ad85d48d9fe6e4d6c63ed68978ac04c0a799
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_ftsdisk_jbdtest_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_ftsdisk_jbdtest
+            +guid:23621cb9-c546-44e9-bded-15731aba500d
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_ftsdisk_jbdtest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('07442f34fd81b7c60e3420689864ad85d48d9fe6e4d6c63ed68978ac04c0a799')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_jittest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_jittest.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using jittest.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jittest.obj=255bc5403265ee525513cbe13d3ad1dfc8c5b41018331b8b882ebd0cbaff6f7d
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_ftsdisk_jittest_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_ftsdisk_jittest
+            +guid:864a908f-3f93-4fc1-9bca-dbf2fdb6fcd1
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_ftsdisk_jittest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('255bc5403265ee525513cbe13d3ad1dfc8c5b41018331b8b882ebd0cbaff6f7d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_jtest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_jtest.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using jtest.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:jtest.obj=9620522f111d932411b3c59ca722470c6f59f97c56ef275180a254e0a485db02
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_ftsdisk_jtest_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_fontdes_ftsdisk_jtest
+            +guid:11b2cbe5-c1ac-441e-a49e-c82fd3483bb6
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_ftsdisk_jtest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('9620522f111d932411b3c59ca722470c6f59f97c56ef275180a254e0a485db02')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_jvrtest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_jvrtest.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using jvrtest.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:jvrtest.obj=60a2ccef2153759531d8d632655bfded50432ebf2bbcbb4c2de08b8026de66ba
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_ftsdisk_jvrtest_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_ftsdisk_jvrtest
+            +guid:dbdb3928-9cef-4b0a-8d29-fd90c57dbf5d
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_ftsdisk_jvrtest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('60a2ccef2153759531d8d632655bfded50432ebf2bbcbb4c2de08b8026de66ba')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_kbdtest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_kbdtest.py
@@ -1,0 +1,65 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kbdtest.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kbdtest.obj=2dd5cd6598beefabd31ec27535bb7b864110e6a18ca9bb00321ed2140eb0b1df
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_ftsdisk_kbdtest_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_ftsdisk_kbdtest
+            +guid:4d9de925-7878-4f01-982e-575c28343d44
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+        +overrides:
+            +Home:
+                +is_manual:False
+                +timeout:360
+                +test:
+                    +dut:
+                        +type:Engine
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_ftsdisk_kbdtest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('2dd5cd6598beefabd31ec27535bb7b864110e6a18ca9bb00321ed2140eb0b1df')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_kittest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_kittest.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kittest.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:kittest.obj=bf2f0a6638cd17bb6fa9dc8328d96dac6832e52698d1c91005a606646f93771d
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_ftsdisk_kittest_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_ftsdisk_kittest
+            +guid:e971a866-b4aa-40e3-bd32-87fa5a481591
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_ftsdisk_kittest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('bf2f0a6638cd17bb6fa9dc8328d96dac6832e52698d1c91005a606646f93771d')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_ktest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_ktest.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using ktest.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:700
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ktest.obj=f0b9c8aa4b6b679435cd25551f3c8ad8e2f02b2c1ed1a050ca522da771359ea8
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_ftsdisk_ktest_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_ftsdisk_ktest
+            +guid:f7e0bcf4-ac4f-4c3a-9a2b-06011162701c
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_ftsdisk_ktest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('f0b9c8aa4b6b679435cd25551f3c8ad8e2f02b2c1ed1a050ca522da771359ea8')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_kvrtest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_kvrtest.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using kvrtest.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:kvrtest.obj=7d55fe6e9a954470fb4a5a87c46d829c2990c0a121adcbfc57dd036de11e0392
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_ftsdisk_kvrtest_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_fontdes_ftsdisk_kvrtest
+            +guid:b18c9380-b87b-41aa-bf57-13f613da2a83
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_ftsdisk_kvrtest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('7d55fe6e9a954470fb4a5a87c46d829c2990c0a121adcbfc57dd036de11e0392')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_sittest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_sittest.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using sittest.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:sittest.obj=4ec8ed9d228edfba4c79657840fd680d24c8c52e58e7fc099d70160bff5aa1b7
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_ftsdisk_sittest_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_ftsdisk_sittest
+            +guid:dbd4cdfd-d475-4d44-9caf-5899a32eb433
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_ftsdisk_sittest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('4ec8ed9d228edfba4c79657840fd680d24c8c52e58e7fc099d70160bff5aa1b7')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_stest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_stest.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using stest.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:stest.obj=eccbfee9387480daa8bb4fd470c1d19b53c18ff9a68d326740836bf9357f1412
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_ftsdisk_stest_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_ftsdisk_stest
+            +guid:23b67c2a-9f30-4a8a-8385-6bdf56f806f0
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_ftsdisk_stest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('eccbfee9387480daa8bb4fd470c1d19b53c18ff9a68d326740836bf9357f1412')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_svrtest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_svrtest.py
@@ -1,0 +1,66 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using svrtest.obj
+        +test_tier: 1
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:PDLSolns
+        +test_framework: TUF
+        +external_files:svrtest.obj=a0f4b7a33be0c93ecdf9d919b0a8f22d8e071a82767e5294b95a9512abc64e15
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_ftsdisk_svrtest_file_then_succeeds
+        +categorization:
+            +segment:Platform
+            +area:Print
+            +feature:PDL
+            +sub_feature:PCL5
+            +interaction:Headless
+            +test_type:Positive
+        +test:
+            +title: test_pcl5_pcl_fontdes_ftsdisk_svrtest
+            +guid:02e6538e-04c5-4bc0-9e56-0ea0739ca887
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_ftsdisk_svrtest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('a0f4b7a33be0c93ecdf9d919b0a8f22d8e071a82767e5294b95a9512abc64e15')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_tittest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_tittest.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using tittest.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:tittest.obj=79668b60e181f1915b04016ffc2c2aec9a4903064195e040c5669bb27591a521
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_ftsdisk_tittest_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_ftsdisk_tittest
+            +guid:a3bf3242-18af-4712-969c-64cbcf41fee6
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_ftsdisk_tittest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('79668b60e181f1915b04016ffc2c2aec9a4903064195e040c5669bb27591a521')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_ttest.py
+++ b/pcl5_new/pcl5-jedi/test_when_printing_pcl5_pcl_fontdes_ftsdisk_ttest.py
@@ -1,0 +1,59 @@
+import logging
+from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType
+from dunetuf.print.new.output.output_saver import OutputSaver
+from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver
+
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+    $$$$$_BEGIN_TEST_METADATA_DECLARATION_$$$$$
+        +purpose: pcl5 pcl using ttest.obj
+        +test_tier: 3
+        +is_manual: False
+        +test_classification: 1
+        +reqid: DUNE-37356
+        +timeout:600
+        +asset:PDL_New
+        +delivery_team:QualityGuild
+        +feature_team:ENTA4ProductTest
+        +test_framework: TUF
+        +external_files:ttest.obj=a17715f682a4fc3242a36d33c27776a973c35d37e0099721d52676a7c19b5405
+        +test_classification:System
+        +name:TestWhenPrintingJPEGFile::test_when_using_pcl5_pcl_fontdes_ftsdisk_ttest_file_then_succeeds
+        +test:
+            +title: test_pcl5_pcl_fontdes_ftsdisk_ttest
+            +guid:b55085ee-a2e1-43de-b767-e8dcd7a15efd
+            +dut:
+                +type:Simulator
+                +configuration: DocumentFormat=PCL5
+
+    $$$$$_END_TEST_METADATA_DECLARATION_$$$$$
+    """
+    def test_when_using_pcl5_pcl_fontdes_ftsdisk_ttest_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('a17715f682a4fc3242a36d33c27776a973c35d37e0099721d52676a7c19b5405')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()

--- a/scripts/convert_next50.py
+++ b/scripts/convert_next50.py
@@ -1,0 +1,147 @@
+import os
+import re
+import uuid
+import textwrap
+
+src_dir = 'pcl5/pcl5-jedi'
+dst_dir = 'pcl5_new/pcl5-jedi'
+os.makedirs(dst_dir, exist_ok=True)
+
+files = [
+    "test_pcl5_pcl_cap_textpath.py",
+    "test_pcl5_pcl_cpedefects_cr43864_jobnamewithamp.py",
+    "test_pcl5_pcl_cpedefects_lsg55412.py",
+    "test_pcl5_pcl_cpedefects_lsg55412_lsg55412_jedi.py",
+    "test_pcl5_pcl_duplex_duplexm1.py",
+    "test_pcl5_pcl_duplex_duplexm3.py",
+    "test_pcl5_pcl_duplex_duplexm6.py",
+    "test_pcl5_pcl_duplex_duplx5a.py",
+    "test_pcl5_pcl_duplex_duplx5b1.py",
+    "test_pcl5_pcl_duplex_duplx5b2.py",
+    "test_pcl5_pcl_duplex_duplx5b3.py",
+    "test_pcl5_pcl_duplex_duplx5c.py",
+    "test_pcl5_pcl_duplex_duplx5e.py",
+    "test_pcl5_pcl_font_andale_selectandalefont_resourcedata.py",
+    "test_pcl5_pcl_font_feature_ffont_cf.py",
+    "test_pcl5_pcl_font_feature_ffont_cf_hw.py",
+    "test_pcl5_pcl_font_feature_fmacro_cf.py",
+    "test_pcl5_pcl_font_feature_fmacro_cf_hw.py",
+    "test_pcl5_pcl_font_feature_gpri_1.py",
+    "test_pcl5_pcl_font_feature_mult_gfont.py",
+    "test_pcl5_pcl_font_feature_overpri_1.py",
+    "test_pcl5_pcl_font_feature_usb_fmacro_cf.py",
+    "test_pcl5_pcl_font_feature_usb_fpri_11.py",
+    "test_pcl5_pcl_font_feature_usb_fpri_12.py",
+    "test_pcl5_pcl_font_feature_usb_fpri_13.py",
+    "test_pcl5_pcl_font_feature_usb_fpri_6.py",
+    "test_pcl5_pcl_font_feature_usb_fpri_8.py",
+    "test_pcl5_pcl_font_feature_usb_fpri_8_hw.py",
+    "test_pcl5_pcl_font_feature_usb_fpri_9.py",
+    "test_pcl5_pcl_font_feature_usb_gpri_1.py",
+    "test_pcl5_pcl_font_feature_usb_mult_gfont.py",
+    "test_pcl5_pcl_font_feature_usb_overpri_1_hw.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_jgoth.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_jminch.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_jpgoth.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_jpminch.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_jpminchbd.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_jpminchit.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_jpminchv.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_jpminchx.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_jpminchy.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_kbatcf.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_kbatcp.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_kdotcf.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_kdotcp.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_kdotcpit.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_kdotcpv.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_kdotcpx.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_kdotcpy.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_kgulcf.py",
+]
+
+meta_re = re.compile(r'(\$\$\$\$\$_BEGIN_TEST_METADATA_DECLARATION_\$\$\$\$\$.*?\$\$\$\$\$_END_TEST_METADATA_DECLARATION_\$\$\$\$\$)', re.S)
+checksum_re = re.compile(r"'([0-9a-f]{32,})'")
+
+for fname in files:
+    with open(os.path.join(src_dir, fname)) as f:
+        content = f.read()
+
+    base = fname[len('test_'):-3]
+    new_fname = f'test_when_printing_{base}.py'
+    dst_path = os.path.join(dst_dir, new_fname)
+
+    m = meta_re.search(content)
+    if not m:
+        raise ValueError(f'Metadata block not found in {fname}')
+    metadata = m.group(1)
+
+    meta_lines = []
+    for line in metadata.splitlines():
+        if '+asset:' in line:
+            line = re.sub(r'\+asset:.*', '+asset:PDL_New', line)
+        if '+delivery_team:' in line:
+            line = re.sub(r'\+delivery_team:.*', '+delivery_team:QualityGuild', line)
+        if '+name:' in line:
+            indent = line[:line.find('+')]
+            line = f"{indent}+name:TestWhenPrintingJPEGFile::test_when_using_{base}_file_then_succeeds"
+        if '+guid:' in line:
+            indent = line[:line.find('+')]
+            line = f"{indent}+guid:{uuid.uuid4()}"
+        meta_lines.append(line)
+    metadata_new = '\n'.join('    ' + ln for ln in meta_lines)
+
+    checksum_match = checksum_re.search(content)
+    checksum = checksum_match.group(1) if checksum_match else ''
+
+    imports = [
+        'import logging',
+        'from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType',
+        'from dunetuf.print.new.output.output_saver import OutputSaver',
+        'from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver',
+    ]
+    import_block = '\n'.join(imports)
+
+    method_lines = textwrap.dedent(f'''\
+    def test_when_using_{base}_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('{checksum}')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+''').splitlines()
+    test_method = '\n'.join('    ' + line if line else '' for line in method_lines)
+
+    class_def = textwrap.dedent(f'''\
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+{metadata_new}
+    """
+{test_method}
+''')
+
+    with open(dst_path, 'w') as out:
+        out.write(import_block + '\n\n' + class_def)

--- a/scripts/convert_next50_part2.py
+++ b/scripts/convert_next50_part2.py
@@ -1,0 +1,147 @@
+import os
+import re
+import uuid
+import textwrap
+
+src_dir = 'pcl5/pcl5-jedi'
+dst_dir = 'pcl5_new/pcl5-jedi'
+os.makedirs(dst_dir, exist_ok=True)
+
+files = [
+    "test_pcl5_pcl_fontdes_2bytetypeface_kgulcp.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_kgungcf.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_khybatf.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_khybatp.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_khydotf.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_khydotp.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_khygulf.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_khygulfbd.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_khygulfit.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_khygulfv.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_khygulfx.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_khygulfy.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_khygulp.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_khygungf.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_khygungp.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_scsfang.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_scsfangbd.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_scsfangit.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_scsfangv.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_scsfangx.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_scshei.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_scskai.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_scssun.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_tckai.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_tcming.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_tcpming.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_tcpmingbd.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_tcpmingit.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_tcpmingv.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_tcpmingx.py",
+    "test_pcl5_pcl_fontdes_2bytetypeface_tcpmingy.py",
+    "test_pcl5_pcl_fontdes_fntfmt16.py",
+    "test_pcl5_pcl_fontdes_fntfmt16_fmt16seg.py",
+    "test_pcl5_pcl_fontdes_font_pri_diskpri.py",
+    "test_pcl5_pcl_fontdes_font_pri_fpri300.py",
+    "test_pcl5_pcl_fontdes_font_pri_simmpri.py",
+    "test_pcl5_pcl_fontdes_fontpri5.py",
+    "test_pcl5_pcl_fontdes_ftsdisk_jbdtest.py",
+    "test_pcl5_pcl_fontdes_ftsdisk_jittest.py",
+    "test_pcl5_pcl_fontdes_ftsdisk_jtest.py",
+    "test_pcl5_pcl_fontdes_ftsdisk_jvrtest.py",
+    "test_pcl5_pcl_fontdes_ftsdisk_kbdtest.py",
+    "test_pcl5_pcl_fontdes_ftsdisk_kittest.py",
+    "test_pcl5_pcl_fontdes_ftsdisk_ktest.py",
+    "test_pcl5_pcl_fontdes_ftsdisk_kvrtest.py",
+    "test_pcl5_pcl_fontdes_ftsdisk_sittest.py",
+    "test_pcl5_pcl_fontdes_ftsdisk_stest.py",
+    "test_pcl5_pcl_fontdes_ftsdisk_svrtest.py",
+    "test_pcl5_pcl_fontdes_ftsdisk_tittest.py",
+    "test_pcl5_pcl_fontdes_ftsdisk_ttest.py",
+]
+
+meta_re = re.compile(r'(\$\$\$\$\$_BEGIN_TEST_METADATA_DECLARATION_\$\$\$\$\$.*?\$\$\$\$\$_END_TEST_METADATA_DECLARATION_\$\$\$\$\$)', re.S)
+checksum_re = re.compile(r"'([0-9a-f]{32,})'")
+
+for fname in files:
+    with open(os.path.join(src_dir, fname)) as f:
+        content = f.read()
+
+    base = fname[len('test_'):-3]
+    new_fname = f'test_when_printing_{base}.py'
+    dst_path = os.path.join(dst_dir, new_fname)
+
+    m = meta_re.search(content)
+    if not m:
+        raise ValueError(f'Metadata block not found in {fname}')
+    metadata = m.group(1)
+
+    meta_lines = []
+    for line in metadata.splitlines():
+        if '+asset:' in line:
+            line = re.sub(r'\+asset:.*', '+asset:PDL_New', line)
+        if '+delivery_team:' in line:
+            line = re.sub(r'\+delivery_team:.*', '+delivery_team:QualityGuild', line)
+        if '+name:' in line:
+            indent = line[:line.find('+')]
+            line = f"{indent}+name:TestWhenPrintingJPEGFile::test_when_using_{base}_file_then_succeeds"
+        if '+guid:' in line:
+            indent = line[:line.find('+')]
+            line = f"{indent}+guid:{uuid.uuid4()}"
+        meta_lines.append(line)
+    metadata_new = '\n'.join('    ' + ln for ln in meta_lines)
+
+    checksum_match = checksum_re.search(content)
+    checksum = checksum_match.group(1) if checksum_match else ''
+
+    imports = [
+        'import logging',
+        'from dunetuf.print.print_common_types import MediaInputIds, MediaSize, MediaType',
+        'from dunetuf.print.new.output.output_saver import OutputSaver',
+        'from tests.print.pdl.print_base import TestWhenPrinting, setup_output_saver, tear_down_output_saver',
+    ]
+    import_block = '\n'.join(imports)
+
+    method_lines = textwrap.dedent(f'''\
+    def test_when_using_{base}_file_then_succeeds(self):
+        self.outputsaver.validate_crc_tiff()
+        job_id = self.print.raw.start('{checksum}')
+        self.print.wait_for_job_completion(job_id)
+        self.outputsaver.save_output()
+''').splitlines()
+    test_method = '\n'.join('    ' + line if line else '' for line in method_lines)
+
+    class_def = textwrap.dedent(f'''\
+class TestWhenPrintingJPEGFile(TestWhenPrinting):
+    @classmethod
+    def setup_class(cls):
+        """Initialize shared test resources."""
+        super().setup_class()
+        cls.outputsaver = OutputSaver()
+        setup_output_saver(cls.outputsaver)
+
+    @classmethod
+    def teardown_class(cls):
+        """Release shared test resources."""
+
+    def teardown_method(self):
+        """Clean up resources after each test."""
+        # Clear job queue
+        self.job_queue.cancel_all_jobs()
+        self.job_queue.wait_for_queue_empty()
+
+        # Clear job history
+        self.job_history.clear()
+        self.job_history.wait_for_history_empty()
+
+        # Reset media configuration to default
+        self.media.update_media_configuration(self.default_configuration)
+        tear_down_output_saver(self.outputsaver)
+    """
+{metadata_new}
+    """
+{test_method}
+''')
+
+    with open(dst_path, 'w') as out:
+        out.write(import_block + '\n\n' + class_def)


### PR DESCRIPTION
## Summary
- convert another 50 pcl5 jedi tests into the new PDL_New framework
- add helper script `convert_next50_part2.py` to automate these conversions

## Testing
- `python -m py_compile $(git status --short | awk '{print $2}' | tr '\n' ' ')`


------
https://chatgpt.com/codex/tasks/task_e_68823e76516c8332857c5e28daafd19d